### PR TITLE
chore(tests): Friendlier run-tests.sh - better warnings, allows override of Dartium path

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -1,11 +1,33 @@
 #!/bin/sh
-CHROME_CANARY_BIN=/Applications/dart/chromium/Chromium.app/Contents/MacOS/Chromium
-DART_FLAGS="--enable-type-checks --enable-asserts"
 
+# OS-specific Dartium path defaults
+case $( uname -s ) in
+  Darwin)
+    CHROME_CANARY_BIN=${CHROME_CANARY_BIN:-"/Applications/dart/chromium/Chromium.app/Contents/MacOS/Chromium"};;
+esac
+if [ ! -x "$CHROME_CANARY_BIN" ]; then
+  echo "Unable to determine path to Dartium browser. To correct:"
+  echo "export CHROME_CANARY_BIN=path/to/dartium"
+  exit 1;
+fi
 export CHROME_CANARY_BIN
-export DART_FLAGS
+export DART_FLAGS="--enable-type-checks --enable-asserts"
 
-node node_modules/karma/bin/karma start karma.conf \
-	--reporters=junit,dots --port=8765 --runner-port=8766 \
-	--browsers=ChromeCanary --single-run --no-colors --no-color
+# Check for node
+if [ -z "$(which node)" ]; then
+  echo "node.js does not appear to be on the path."
+  echo "You can obtain it from http://nodejs.org"
+  exit 1;
+fi
+
+# Check for karma
+KARMA_PATH="node_modules/karma/bin/karma"
+if [ ! -e "$KARMA_PATH" ]; then
+  echo "karma does not appear to be installed. Installing:"
+  npm install
+fi
+
+node "$KARMA_PATH" start karma.conf \
+  --reporters=junit,dots --port=8765 --runner-port=8766 \
+  --browsers=ChromeCanary --single-run --no-colors --no-color
 


### PR DESCRIPTION
1. Defaults, but no longer overrides CHROME_CANARY_BIN
2. Adds a mechanism for setting OS-dependent defaults
3. Checks for node on path
4. Does an npm install karma-dart@canary if not installed
5. Corrects the path to karma
