### PR TITLE
refactor: update to use the new di API

### DIFF
--- a/bin/parser_generator_for_spec.dart
+++ b/bin/parser_generator_for_spec.dart
@@ -1,13 +1,15 @@
 import 'package:di/di.dart';
+import 'package:di/dynamic_injector.dart';
 import 'package:angular/parser/parser_library.dart';
 import 'package:angular/tools/parser_generator/dart_code_gen.dart';
 import 'package:angular/tools/parser_generator/generator.dart';
 
 main() {
   Module module = new Module()
-    ..type(ParserBackend, DartCodeGen);
+    ..type(ParserBackend, implementedBy: DartCodeGen);
 
-  Injector injector = new Injector([module]);
+  Injector injector = new DynamicInjector(modules: [module],
+      allowImplicitInjection: true);
 
   // List generated using:
   // node node_modules/karma/bin/karma run | grep -Eo ":XNAY:.*:XNAY:" | sed -e 's/:XNAY://g' | sed -e "s/^/'/" | sed -e "s/$/',/" | sort | uniq > missing_expressions

--- a/lib/directives/ng_controller.dart
+++ b/lib/directives/ng_controller.dart
@@ -11,14 +11,14 @@ class NgControllerAttrDirective {
   BlockHole blockHole;
   Injector injector;
   Scope scope;
+  ControllerRegistry controllerRegistry;
 
-  Symbol ctrlSymbol;
   String alias;
 
   set expression(value) {
     var match = CTRL_REGEXP.firstMatch(value);
 
-    ctrlSymbol = new Symbol(match.group(1) + 'Controller');
+    Type ctrlType = controllerRegistry[match.group(1)];
     alias = match.group(3);
 
     scope.$evalAsync(() {
@@ -28,9 +28,9 @@ class NgControllerAttrDirective {
       boundBlockFactory(childScope).insertAfter(blockHole);
 
       // instantiate the controller
-      var controller = injector.
-      createChild([new ScopeModule(childScope)], [ctrlSymbol]).
-      getBySymbol(ctrlSymbol);
+      var controller = injector
+          .createChild([new ScopeModule(childScope)],
+                       forceNewInstances: [ctrlType]).get(ctrlType);
 
       // publish the controller into the scope
       if (alias != null) {
@@ -42,5 +42,6 @@ class NgControllerAttrDirective {
   NgControllerAttrDirective(BoundBlockFactory this.boundBlockFactory,
                             BlockHole this.blockHole,
                             Injector this.injector,
-                            Scope this.scope);
+                            Scope this.scope,
+                            ControllerRegistry this.controllerRegistry);
 }

--- a/lib/tools/parser_generator/generator.dart
+++ b/lib/tools/parser_generator/generator.dart
@@ -106,7 +106,7 @@ call(String t) {
     generatedMain() {
   describe(\'generated parser\', () {
     beforeEach(module((AngularModule module) {
-      module.type(Parser, GeneratedParser);
+      module.type(Parser, implementedBy: GeneratedParser);
     }));
     main();
   });

--- a/test/_specs.dart
+++ b/test/_specs.dart
@@ -9,7 +9,7 @@ import 'dart:mirrors' as mirror;
 import 'package:angular/angular.dart';
 import 'jasmine_syntax.dart';
 import 'package:di/di.dart';
-import 'package:unittest/mock.dart';
+import 'package:di/dynamic_injector.dart';
 import "_log.dart";
 import "_http.dart";
 
@@ -17,7 +17,7 @@ export 'package:unittest/unittest.dart';
 export 'package:angular/debug.dart';
 export 'package:angular/angular.dart';
 export 'dart:html';
-export 'jasmine_syntax.dart';
+export 'jasmine_syntax.dart' hide main;
 export 'package:di/di.dart';
 export 'package:unittest/mock.dart';
 export 'package:perf_api/perf_api.dart';
@@ -208,17 +208,17 @@ async(Function fn) =>
   };
 
 class SpecInjector {
-  Injector moduleInjector;
-  Injector injector;
+  DynamicInjector moduleInjector;
+  DynamicInjector injector;
   List<Module> modules = [];
   DirectiveRegistry directives = new DirectiveRegistry();
   List<Function> initFns = [];
 
   SpecInjector() {
     var moduleModule = new Module()
-      ..factory(AngularModule, () => addModule(new AngularModule()))
-      ..factory(Module, () => addModule(new Module()));
-    moduleInjector = new Injector([moduleModule], false);
+      ..factory(AngularModule, (Injector injector) => addModule(new AngularModule()))
+      ..factory(Module, (Injector injector) => addModule(new Module()));
+    moduleInjector = new DynamicInjector(modules: [moduleModule]);
   }
 
   addModule(module) {
@@ -240,7 +240,7 @@ class SpecInjector {
   inject(Function fn, declarationStack) {
     try {
       if (injector == null) {
-        injector = new Injector(modules, false); // Implicit injection is disabled.
+        injector = new DynamicInjector(modules: modules); // Implicit injection is disabled.
         initFns.forEach((fn) => injector.invoke(fn));
       }
       injector.invoke(fn);
@@ -281,10 +281,10 @@ main() {
   beforeEach(() => currentSpecInjector = new SpecInjector());
   beforeEach(module((AngularModule module) {
     module
-      ..type(Logger, Logger)
-      ..type(MockHttp, MockHttp)
-      ..type(Zone, Zone)
-      ..type(Log, Log);
+      ..type(Logger)
+      ..type(MockHttp)
+      ..type(Zone)
+      ..type(Log);
   }));
   afterEach(() => currentSpecInjector = null);
 }

--- a/test/_test_bed.dart
+++ b/test/_test_bed.dart
@@ -35,7 +35,7 @@ class TestBed {
 
 beforeEachTestBed(assign) {
   return module((AngularModule module) {
-    module.type(TestBed, TestBed);
+    module.type(TestBed);
     module.directive(Probe);
     return (TestBed tb) => assign(tb);
   });

--- a/test/directives/ng_controller_spec.dart
+++ b/test/directives/ng_controller_spec.dart
@@ -17,8 +17,8 @@ main() {
   describe('NgController', () {
     var compile, element, rootScope;
 
-    beforeEach(module((Module module) {
-      module.type(MainController, MainController);
+    beforeEach(module((AngularModule module) {
+      module.controller('Main', MainController);
     }));
 
     beforeEach(inject((Scope scope, Compiler compiler, Injector injector) {
@@ -32,13 +32,13 @@ main() {
 
 
     it('should instantiate controller', () {
-      compile('<div><div ng-controller="ctrlTest.Main" class="controller">Hi {{name}}</div></div>');
+      compile('<div><div ng-controller="Main" class="controller">Hi {{name}}</div></div>');
       expect(element.find('.controller').text()).toEqual('Hi Vojta');
     });
 
 
     it('should create a new scope', () {
-      compile('<div><div ng-controller="ctrlTest.Main" class="controller">Hi {{name}}</div><div class="siblink">{{name}}</div></div>', () {
+      compile('<div><div ng-controller="Main" class="controller">Hi {{name}}</div><div class="siblink">{{name}}</div></div>', () {
         rootScope['name'] = 'parent';
       });
 
@@ -48,7 +48,7 @@ main() {
 
 
     it('should export controller', () {
-      compile('<div><div ng-controller="ctrlTest.Main as main" class="controller">Hi {{main.name}}</div></div>');
+      compile('<div><div ng-controller="Main as main" class="controller">Hi {{main.name}}</div></div>');
       expect(element.find('.controller').text()).toEqual('Hi name on controller');
     });
   });

--- a/test/http_spec.dart
+++ b/test/http_spec.dart
@@ -27,7 +27,7 @@ main() {
     describe('url rewriting', () {
       beforeEach(module((AngularModule module) {
         module
-          ..type(UrlRewriter, SubstringRewriter);
+          ..type(UrlRewriter, implementedBy: SubstringRewriter);
       }));
 
 

--- a/test/scope_spec.dart
+++ b/test/scope_spec.dart
@@ -104,7 +104,7 @@ main() {
 
       it(r'should delegate exceptions', () {
         module((AngularModule module) {
-          module.type(ExceptionHandler, LogExceptionHandler);
+          module.type(ExceptionHandler, implementedBy: LogExceptionHandler);
         });
         inject((Scope $rootScope, ExceptionHandler $exceptionHandler) {
           $rootScope.$watch('a', () {throw 'abc';});
@@ -232,7 +232,7 @@ main() {
 
       it(r'should watch functions', () {
         module((AngularModule module) {
-          module.type(ExceptionHandler, LogExceptionHandler);
+          module.type(ExceptionHandler, implementedBy: LogExceptionHandler);
         });
         inject((Scope $rootScope, ExceptionHandler exceptionHandler) {
           $rootScope.fn = () {return 'a';};
@@ -446,7 +446,7 @@ main() {
 
 
       it(r'should catch exceptions', () {
-        module((Module module) => module.type(ExceptionHandler, LogExceptionHandler));
+        module((Module module) => module.type(ExceptionHandler, implementedBy: LogExceptionHandler));
         inject((Scope $rootScope, ExceptionHandler $exceptionHandler) {
           var log = [];
           var child = $rootScope.$new();
@@ -464,7 +464,7 @@ main() {
       describe(r'exceptions', () {
         var log;
         beforeEach(module((AngularModule module) {
-          return module.type(ExceptionHandler, LogExceptionHandler);
+          return module.type(ExceptionHandler, implementedBy: LogExceptionHandler);
         }));
         beforeEach(inject((Scope $rootScope) {
           log = '';
@@ -607,7 +607,7 @@ main() {
         }
 
         beforeEach(module((AngularModule module) {
-          return module.type(ExceptionHandler, LogExceptionHandler);
+          return module.type(ExceptionHandler, implementedBy: LogExceptionHandler);
         }));
         beforeEach(inject((Scope $rootScope) {
           log = [];

--- a/test/templateurl_spec.dart
+++ b/test/templateurl_spec.dart
@@ -30,7 +30,7 @@ main() {
       module
         ..directive(HtmlAndCssComponent)
         ..value(HttpBackend, backend)
-        ..type(UrlRewriter, PrefixedUrlRewriter);
+        ..type(UrlRewriter, implementedBy: PrefixedUrlRewriter);
     }));
 
     it('should use the UrlRewriter for both HTML and CSS URLs', async(inject((Http $http, Compiler $compile, Scope $rootScope, Log log, Injector injector, Zone zone) {


### PR DESCRIPTION
Depends on https://github.com/angular/di.dart/pull/11
- Switched to new di API throughout.
- Updated tests to use DynamicInjector.
- Added ControllerRegistry and AngularModule.controller. Updated ng-controller.
