### PR TITLE
feat(NgAnnotations): allow ignoring child nodes during compilation

### DIFF
--- a/lib/directive.dart
+++ b/lib/directive.dart
@@ -3,6 +3,16 @@ library angular.service.directive;
 import 'package:di/di.dart';
 import 'registry.dart';
 
+/**
+ * Common constants and enums that apply across [NgDirective] and [NgComponent].
+ */
+class NgAnnotation {
+  // Enum values for the 'children' property.
+  static const String COMPILE_CHILDREN = 'compile';
+  static const String TRANSCLUDE_CHILDREN = 'transclude';
+  static const String IGNORE_CHILDREN = 'ignore';
+}
+
 class NgAnnotationBase {
   /**
    * CSS selector which will trigger this component/directive.
@@ -17,6 +27,20 @@ class NgAnnotationBase {
    * Example: `input[type=checkbox][ng-model]`
    */
   final String selector;
+
+  /**
+   * Specifies the compiler action to be taken on the child nodes of the
+   * element which this currently being compiled.  The values are:
+   *
+   * * `compile` [NgAnnotation.COMPILE_CHILDREN] - compile the child nodes
+   *   of the element.  This is the default.
+   * * `transclude` [NgAnnotation.TRANSCLUDE_CHILDREN] - compile the child
+   *   nodes for transclusion and makes available [BoundBlockFactory],
+   *   [BlockFactory] and [BlockHole] for injection.
+   * * `ignore` [NgAnnotation.IGNORE_CHILDREN] - do not compile/visit the
+   *   child nodes.  Angular markup on descendants will not be processed.
+   */
+  final String children;
 
   /**
    * A directive/component controller class can be injected into other
@@ -121,6 +145,7 @@ class NgAnnotationBase {
 
   const NgAnnotationBase({
     this.selector,
+    this.children: NgAnnotation.COMPILE_CHILDREN,
     this.visibility: NgDirective.LOCAL_VISIBILITY,
     this.publishAs,
     this.publishTypes: const [],
@@ -134,22 +159,6 @@ class NgAnnotationBase {
   operator==(other) =>
       other is NgAnnotationBase && this.selector == other.selector;
 
-}
-
-
-// Explicitly pass all the named parameters to work around dartbug.com/13556
-/**
- * Meta-data marker placed on a class to make the compiler skip processing
- * Angular constructs on the element matched by the specified selector and all
- * of its descendants.  This allows one to have DOM nodes that contains Angular
- * markup but should not be processed as a template.
- */
-class NgNonBindable extends NgAnnotationBase {
-  const NgNonBindable({ selector }) : super(
-      selector: selector, visibility: null,
-      publishTypes: null, map: null,
-      exportExpressions: null,
-      exportExpressionAttrs: null);
 }
 
 
@@ -211,10 +220,14 @@ class NgComponent extends NgAnnotationBase {
     publishTypes : const <Type>[],
     exportExpressions,
     exportExpressionAttrs
-  }) : super(selector: selector, visibility: visibility,
-      publishTypes: publishTypes, publishAs: publishAs, map: map,
-      exportExpressions: exportExpressions,
-      exportExpressionAttrs: exportExpressionAttrs);
+  }) : super(selector: selector,
+             children: NgAnnotation.COMPILE_CHILDREN,
+             visibility: visibility,
+             publishTypes: publishTypes,
+             publishAs: publishAs,
+             map: map,
+             exportExpressions: exportExpressions,
+             exportExpressionAttrs: exportExpressionAttrs);
 }
 
 RegExp _ATTR_NAME = new RegExp(r'\[([^\]]+)\]$');
@@ -224,11 +237,10 @@ class NgDirective extends NgAnnotationBase {
   static const String CHILDREN_VISIBILITY = 'children';
   static const String DIRECT_CHILDREN_VISIBILITY = 'direct_children';
 
-  final bool transclude;
   final String attrName;
 
   const NgDirective({
-    this.transclude: false,
+    children: NgAnnotation.COMPILE_CHILDREN,
     this.attrName: null,
     publishAs,
     map,
@@ -237,7 +249,7 @@ class NgDirective extends NgAnnotationBase {
     publishTypes : const <Type>[],
     exportExpressions,
     exportExpressionAttrs
-  }) : super(selector: selector, visibility: visibility,
+  }) : super(selector: selector, children: children, visibility: visibility,
       publishTypes: publishTypes, publishAs: publishAs, map: map,
       exportExpressions: exportExpressions,
       exportExpressionAttrs: exportExpressionAttrs);

--- a/lib/directives/ng_if.dart
+++ b/lib/directives/ng_if.dart
@@ -85,7 +85,7 @@ abstract class _NgUnlessIfAttrDirectiveBase {
  *     </div>
  */
 @NgDirective(
-    transclude: true,
+    children: NgAnnotation.TRANSCLUDE_CHILDREN,
     selector:'[ng-if]',
     map: const {'.': '=.condition'})
 class NgIfDirective extends _NgUnlessIfAttrDirectiveBase {
@@ -141,7 +141,7 @@ class NgIfDirective extends _NgUnlessIfAttrDirectiveBase {
  *     </div>
  */
 @NgDirective(
-    transclude: true,
+    children: NgAnnotation.TRANSCLUDE_CHILDREN,
     selector:'[ng-unless]',
     map: const {'.': '=.condition'})
 class NgUnlessDirective extends _NgUnlessIfAttrDirectiveBase {

--- a/lib/directives/ng_non_bindable.dart
+++ b/lib/directives/ng_non_bindable.dart
@@ -1,10 +1,10 @@
 part of angular.directive;
 
 /**
- * Causes the compiler to ignore all other directives and Angular markup present
- * on the matched elements and all of their descendants.  This allows one to
- * have DOM nodes that contains Angular markup but should not be processed as a
- * template.
+ * Causes the compiler to ignore all Angular directives and markup on descendant
+ * nodes of the matching element.  Note, however, that other directives and
+ * markup on the element are still processed and that only descending the DOM
+ * for compilation is prevented.
  *
  * Example:
  *
@@ -13,9 +13,11 @@ part of angular.directive;
  *     </div>
  *
  * In the above example, because the `div` element has the `ng-non-bindable`
- * attribute set on it, `foo` attribute won't be processed.  The `ng-bind`
- * directive and the interpolation for `{{b}}` are also not processed because
- * Angular will not process the `span` child element.
+ * attribute set on it, the `ng-bind` directive and the interpolation for
+ * `{{b}}` are not processed because Angular will not process the `span` child
+ * element.  However, the `foo` attribute *will* be interpolated because it is
+ * not on a child node. 
  */
-@NgNonBindable(selector: '[ng-non-bindable]')
+@NgDirective(selector: '[ng-non-bindable]',
+             children: NgAnnotation.IGNORE_CHILDREN)
 class NgNonBindableDirective {}

--- a/lib/directives/ng_repeat.dart
+++ b/lib/directives/ng_repeat.dart
@@ -12,7 +12,7 @@ class _Row {
 }
 
 @NgDirective(
-    transclude: true,
+    children: NgAnnotation.TRANSCLUDE_CHILDREN,
     selector: '[ng-repeat]',
     map: const {'.': '@.expression'})
 class NgRepeatDirective  {

--- a/lib/directives/ng_switch.dart
+++ b/lib/directives/ng_switch.dart
@@ -110,7 +110,7 @@ class _Case {
 
 @NgDirective(
     selector: '[ng-switch-when]',
-    transclude: true,
+    children: NgAnnotation.TRANSCLUDE_CHILDREN,
     map: const {
       '.': '@.value'
     }
@@ -131,7 +131,7 @@ class NgSwitchWhenDirective {
 
 
 @NgDirective(
-    transclude: true,
+    children: NgAnnotation.TRANSCLUDE_CHILDREN,
     selector: '[ng-switch-default]'
 )
 class NgSwitchDefaultDirective {

--- a/lib/dom/block_factory.dart
+++ b/lib/dom/block_factory.dart
@@ -163,7 +163,9 @@ class BlockFactory {
       for (var publishType in ref.annotation.publishTypes) {
         nodeModule.factory(publishType, (Injector injector) => injector.get(ref.type), visibility: visibility);
       }
-      if (annotation is NgDirective && (annotation as NgDirective).transclude) {
+      if (annotation.children == NgAnnotation.TRANSCLUDE_CHILDREN) {
+        // Currently, transclude is only supported for NgDirective.
+        assert(annotation is NgDirective);
         blockHoleFactory = (_) => new BlockHole([node]);
         blockFactory = (_) => ref.blockFactory;
         boundBlockFactory = (Injector injector) => ref.blockFactory.bind(injector);

--- a/lib/dom/compiler.dart
+++ b/lib/dom/compiler.dart
@@ -29,7 +29,7 @@ class Compiler {
       var declaredDirectiveRefs = useExistingDirectiveRefs == null
           ?  selector(domCursor.nodeList()[0])
           : useExistingDirectiveRefs;
-      var compileChildren = true;
+      var children = NgAnnotation.COMPILE_CHILDREN;
       var childDirectivePositions = null;
       List<DirectiveRef> usableDirectiveRefs = null;
 
@@ -40,19 +40,19 @@ class Compiler {
         NgAnnotationBase annotation = directiveRef.annotation;
         var blockFactory = null;
 
-        if (annotation is NgNonBindable) {
-          compileChildren = false;
-          break;
+        print("CKCK: annotation.children: ${annotation.children}, selector: ${annotation.selector}");
+        if (annotation.children != children &&
+            children == NgAnnotation.COMPILE_CHILDREN) {
+          children = annotation.children;
         }
 
-        if (annotation is NgDirective && (annotation as NgDirective).transclude) {
+        if (children == NgAnnotation.TRANSCLUDE_CHILDREN) {
           var remainingDirectives = declaredDirectiveRefs.sublist(j + 1);
           blockFactory = compileTransclusion(
               domCursor, templateCursor,
               directiveRef, remainingDirectives);
 
           j = jj; // stop processing further directives since they belong to transclusion;
-          compileChildren = false;
         }
         if (usableDirectiveRefs == null) {
           usableDirectiveRefs = [];
@@ -61,12 +61,10 @@ class Compiler {
         usableDirectiveRefs.add(directiveRef);
       }
 
-      if (compileChildren && domCursor.descend()) {
+      if (children == NgAnnotation.COMPILE_CHILDREN && domCursor.descend()) {
         templateCursor.descend();
 
-        childDirectivePositions = compileChildren
-            ? _compileBlock(domCursor, templateCursor, null)
-            : null;
+        childDirectivePositions = _compileBlock(domCursor, templateCursor, null);
 
         domCursor.ascend();
         templateCursor.ascend();

--- a/lib/dom/selector.dart
+++ b/lib/dom/selector.dart
@@ -308,10 +308,8 @@ DirectiveSelector directiveSelectorFactory(DirectiveMap directives) {
 }
 
 int _directivePriority(NgAnnotationBase annotation) {
-  if (annotation is NgNonBindable) {
-    return 3;
-  } else if (annotation is NgDirective) {
-    return (annotation as NgDirective).transclude ? 2 : 1;
+  if (annotation is NgDirective) {
+    return (annotation.children == NgAnnotation.TRANSCLUDE_CHILDREN) ? 2 : 1;
   } else if (annotation is NgComponent) {
     return 0;
   }

--- a/test/directives/ng_if_spec.dart
+++ b/test/directives/ng_if_spec.dart
@@ -5,7 +5,7 @@ import 'dart:html' as dom;
 
 @NgDirective(
     selector: '[child-controller]',
-    transclude: true)
+    children: NgAnnotation.TRANSCLUDE_CHILDREN)
 class ChildController {
   ChildController(BoundBlockFactory boundBlockFactory,
                   BlockHole blockHole,

--- a/test/directives/ng_non_bindable_spec.dart
+++ b/test/directives/ng_non_bindable_spec.dart
@@ -9,7 +9,7 @@ main() {
 
     beforeEach(beforeEachTestBed((tb) => _ = tb));
 
-    it('should set ignore all other markup/directives on the element and its descendants',
+    it('should set ignore all other markup/directives on the descendent nodes',
           inject((Scope scope, Injector injector, Compiler compiler) {
       var element = $('<div>' +
                       '  <span id="s1">{{a}}</span>' +
@@ -31,8 +31,9 @@ main() {
       expect(element.find("#s4").text().trim()).toEqual('two');
       // Bindings contained by ng-non-bindable should be left alone.
       var nonBindableDiv = element.find("div");
-      expect(nonBindableDiv.attr('foo')).toEqual('{{a}}');
       expect(nonBindableDiv.text().trim()).toEqual('{{b}}');
+      // Bindings on the same node are processed.
+      expect(nonBindableDiv.attr('foo')).toEqual('one');
     }));
   });
 }

--- a/test/dom/block_spec.dart
+++ b/test/dom/block_spec.dart
@@ -2,7 +2,7 @@ library block_spec;
 
 import '../_specs.dart';
 
-@NgDirective(transclude: true, selector: 'foo')
+@NgDirective(children: NgAnnotation.TRANSCLUDE_CHILDREN, selector: 'foo')
 class LoggerBlockDirective {
   LoggerBlockDirective(BlockHole hole, BlockFactory blockFactory,
       BoundBlockFactory boundBlockFactory, Logger logger) {
@@ -135,7 +135,10 @@ main() {
           //   }
           // }
 
-          var directiveRef = new DirectiveRef(null, LoggerBlockDirective, new NgDirective(transclude: true, selector: 'foo'), '');
+          var directiveRef = new DirectiveRef(null,
+                                              LoggerBlockDirective,
+                                              new NgDirective(children: NgAnnotation.TRANSCLUDE_CHILDREN, selector: 'foo'),
+                                              '');
           directiveRef.blockFactory = new BlockFactory($('<b>text</b>'), [], perf);
           var outerBlockType = new BlockFactory(
               $('<!--start--><!--end-->'),

--- a/test/dom/compiler_spec.dart
+++ b/test/dom/compiler_spec.dart
@@ -468,7 +468,7 @@ class LocalAttrDirective {
 
 @NgDirective(
     selector: '[simple-transclude-in-attach]',
-    visibility: NgDirective.CHILDREN_VISIBILITY, transclude: true)
+    visibility: NgDirective.CHILDREN_VISIBILITY, children: NgAnnotation.TRANSCLUDE_CHILDREN)
 class SimpleTranscludeInAttachAttrDirective {
   SimpleTranscludeInAttachAttrDirective(BlockHole blockHole, BoundBlockFactory boundBlockFactory, Logger log, Scope scope) {
     scope.$evalAsync(() {

--- a/test/dom/selector_spec.dart
+++ b/test/dom/selector_spec.dart
@@ -15,9 +15,12 @@ import '../_specs.dart';
 @NgComponent(selector:'component')            class _Component{}
 @NgDirective(selector:'[attribute]')          class _Attribute{}
 @NgDirective(selector:'[structural]',
-             transclude: true)                class _Structural{}
+             children: NgAnnotation.TRANSCLUDE_CHILDREN)
+                                              class _Structural{}
 
-@NgNonBindable(selector:'[non-bindable]')     class _NonBindable{}
+@NgDirective(selector:'[ignore-children]',
+             children: NgAnnotation.IGNORE_CHILDREN)
+                                              class _IgnoreChildren{}
 
 main() {
   describe('Selector', () {
@@ -44,7 +47,7 @@ main() {
         ..type(_Component)
         ..type(_Attribute)
         ..type(_Structural)
-        ..type(_NonBindable);
+        ..type(_IgnoreChildren);
     }));
     beforeEach(inject((DirectiveMap directives) {
       selector = directiveSelectorFactory(directives);
@@ -127,11 +130,11 @@ main() {
 
     it('should sort by priority', () {
       expect(selector(element = e(
-          '<component attribute non-bindable structural></component>')),
+          '<component attribute ignore-children structural></component>')),
       toEqualsDirectiveInfos([
-          { "selector": "[non-bindable]", "value": "", "element": element },
           { "selector": "[structural]", "value": "", "element": element },
           { "selector": "[attribute]", "value": "", "element": element },
+          { "selector": "[ignore-children]", "value": "", "element": element },
           { "selector": "component", "value": null, "element": element }
       ]));
     });


### PR DESCRIPTION
BREAKING CHANGE:
- `NgDirective` loses `transclude`.  Transclusion is indicated by setting
  the `children` string enum to `NgAnnotationBase.TRANSCLUDE_CHILDREN`.
- `NgNonBindableDirective` / `ng-non-bindable` suppressing compilation only
  on the child nodes but does not prevent processing other directives or
  interpolations on the same node.
