### PR TITLE
chore(sdk): remove uses of meta package

### DIFF
--- a/lib/core/module.dart
+++ b/lib/core/module.dart
@@ -7,7 +7,6 @@ import 'dart:mirrors';
 
 import 'package:di/di.dart';
 import 'package:perf_api/perf_api.dart';
-import 'package:meta/meta.dart' as meta;
 
 import 'parser/parser_library.dart';
 import '../utils.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
   html5lib: ">=0.8.7 <0.10.0"
   intl: ">=0.8.7 <0.10.0"
   js: ">=0.2.0 <0.3.0"
-  meta: ">=0.8.7 <0.10.0"
   perf_api: ">=0.0.8 <0.1.0"
   route_hierarchical: ">=0.4.7 <0.5.0"
   unittest: ">=0.8.7 <0.10.0"

--- a/test/core/parser/parser_spec.dart
+++ b/test/core/parser/parser_spec.dart
@@ -1,7 +1,6 @@
 library parser_spec;
 
 import '../../_specs.dart';
-import 'package:meta/meta.dart';
 
 // Used to test getter / setter logic.
 class TestData {


### PR DESCRIPTION
As of 0.8.10, annotations in the meta package have been migrated to dart:core.
