### PR TITLE
feat(probe): Access injector, scope, directives from REPL

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,6 +8,7 @@ module.exports = function(config) {
     // all tests must be 'included', but all other libraries must be 'served' and
     // optionally 'watched' only.
     files: [
+      'test/jasmine_syntax.dart',
       'test/*.dart',
       'test/**/*_spec.dart',
       'test/config/filter_tests.dart',

--- a/lib/angular.dart
+++ b/lib/angular.dart
@@ -30,3 +30,4 @@ export 'package:angular/filter/module.dart';
 export 'package:angular/routing/module.dart';
 
 part 'bootstrap.dart';
+part 'introspection.dart';

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -20,6 +20,7 @@ class AngularModule extends Module {
     install(new NgRoutingModule());
 
     type(MetadataExtractor);
+    value(Expando, _elementExpando);
   }
 }
 

--- a/lib/core_dom/compiler.dart
+++ b/lib/core_dom/compiler.dart
@@ -4,10 +4,12 @@ class Compiler {
   final DirectiveMap directives;
   final Profiler _perf;
   final Parser _parser;
+  final Expando _expando;
 
   DirectiveSelector selector;
 
-  Compiler(DirectiveMap this.directives, Profiler this._perf, Parser this._parser) {
+  Compiler(DirectiveMap this.directives, Profiler this._perf, Parser this._parser,
+           Expando this._expando) {
     selector = directiveSelectorFactory(directives);
   }
 
@@ -90,7 +92,7 @@ class Compiler {
     var directivePositions = _compileBlock(domCursor, transcludeCursor, transcludedDirectiveRefs);
     if (directivePositions == null) directivePositions = [];
 
-    blockFactory = new BlockFactory(transcludeCursor.elements, directivePositions, _perf);
+    blockFactory = new BlockFactory(transcludeCursor.elements, directivePositions, _perf, _expando);
     domCursor.index = domCursorIndex;
 
     if (domCursor.isInstance()) {
@@ -120,7 +122,7 @@ class Compiler {
         null);
 
     var blockFactory = new BlockFactory(templateElements,
-        directivePositions == null ? [] : directivePositions, _perf);
+        directivePositions == null ? [] : directivePositions, _perf, _expando);
 
     assert(_perf.stopTimer(timerId) != false);
     return blockFactory;

--- a/lib/introspection.dart
+++ b/lib/introspection.dart
@@ -1,0 +1,56 @@
+part of angular;
+
+/**
+ * A global write only variable which keeps track of objects attached to the elements.
+ * This is usefull for debugging AngularDart application from the browser's REPL.
+ */
+Expando _elementExpando = new Expando('element');
+
+/**
+ * Return the closest [ElementProbe] object for a given [Element].
+ *
+ * NOTE: This global method is here to make it easier to debug Angular application from
+ *       the browser's REPL, unit or end-to-end tests. The function is not intended to
+ *       be called from Angular application.
+ */
+ElementProbe ngProbe(dom.Node node) {
+  while(node != null) {
+    var probe = _elementExpando[node];
+    if (probe != null) return probe;
+    node = node.parent;
+  }
+  return null;
+}
+
+
+/**
+ * Return the [Injector] associated with a current [Element].
+ *
+ * **NOTE**: This global method is here to make it easier to debug Angular application from
+ * the browser's REPL, unit or end-to-end tests. The function is not intended to be called
+ * from Angular application.
+ */
+Injector ngInjector(dom.Node node) => ngProbe(node).injector;
+
+
+/**
+ * Return the [Scope] associated with a current [Element].
+ *
+ * **NOTE**: This global method is here to make it easier to debug Angular application from
+ * the browser's REPL, unit or end-to-end tests. The function is not intended to be called
+ * from Angular application.
+ */
+Scope ngScope(dom.Node node) => ngProbe(node).scope;
+
+
+/**
+ * Return a List of directive controllers associated with a current [Element].
+ *
+ * **NOTE**: This global method is here to make it easier to debug Angular application from
+ * the browser's REPL, unit or end-to-end tests. The function is not intended to be called
+ * from Angular application.
+ */
+List<Object> ngDirectives(dom.Node node) {
+  ElementProbe probe = _elementExpando[node];
+  return probe == null ? [] : probe.directives;
+}

--- a/test/core_dom/block_spec.dart
+++ b/test/core_dom/block_spec.dart
@@ -46,12 +46,13 @@ main() {
 
     describe('mutation', () {
       var a, b;
+      var expando = new Expando();
 
       beforeEach(inject((Injector injector, Profiler perf) {
         $rootElement.html('<!-- anchor -->');
         anchor = new BlockHole($rootElement.contents().eq(0));
-        a = (new BlockFactory($('<span>A</span>a'), [], perf))(injector);
-        b = (new BlockFactory($('<span>B</span>b'), [], perf))(injector);
+        a = (new BlockFactory($('<span>A</span>a'), [], perf, expando))(injector);
+        b = (new BlockFactory($('<span>B</span>b'), [], perf, expando))(injector);
       }));
 
 
@@ -139,11 +140,12 @@ main() {
                                               LoggerBlockDirective,
                                               new NgDirective(children: NgAnnotation.TRANSCLUDE_CHILDREN, selector: 'foo'),
                                               '');
-          directiveRef.blockFactory = new BlockFactory($('<b>text</b>'), [], perf);
+          directiveRef.blockFactory = new BlockFactory($('<b>text</b>'), [], perf, new Expando());
           var outerBlockType = new BlockFactory(
               $('<!--start--><!--end-->'),
               [ 0, [ directiveRef ], null],
-              perf);
+              perf,
+              new Expando());
 
           var outterBlock = outerBlockType(injector);
           // The LoggerBlockDirective caused a BlockHole for innerBlockType to

--- a/test/introspection_spec.dart
+++ b/test/introspection_spec.dart
@@ -1,0 +1,16 @@
+library introspection_spec;
+
+import '_specs.dart';
+
+main() => ddescribe('introspection', () {
+  it('should retrieve ElementProbe', inject((TestBed _) {
+    _.compile('<div ng-bind="true"></div>');
+    ElementProbe probe = ngProbe(_.rootElement);
+    expect(probe.injector.parent).toBe(_.injector);
+    expect(ngInjector(_.rootElement).parent).toBe(_.injector);
+    expect(probe.directives[0] is NgBindDirective).toBe(true);
+    expect(ngDirectives(_.rootElement)[0] is NgBindDirective).toBe(true);
+    expect(probe.scope).toBe(_.rootScope);
+    expect(ngScope(_.rootElement)).toBe(_.rootScope);
+  }));
+});


### PR DESCRIPTION
Add global methods to make it easier to debug Angular application from
the browser's REPL, unit or end-to-end tests.
