### PR TITLE
Make test/tools/* not depend on dart:html

### DIFF
--- a/test/tools/html_extractor_spec.dart
+++ b/test/tools/html_extractor_spec.dart
@@ -1,9 +1,10 @@
 library html_extractor_spec;
 
-import '../_specs.dart';
-
-import 'package:angular/tools/html_extractor.dart';
 import 'package:angular/tools/common.dart';
+import 'package:angular/tools/html_extractor.dart';
+import 'package:unittest/unittest.dart';
+
+import '../jasmine_syntax.dart';
 import 'mock_io_service.dart';
 
 main() => describe('html_extractor', () {

--- a/test/tools/selector_spec.dart
+++ b/test/tools/selector_spec.dart
@@ -1,9 +1,10 @@
 library angular.selector_spec;
 
-import '../_specs.dart' hide Node, Element, Text;
-
 import 'package:angular/tools/selector.dart';
 import 'package:html5lib/dom.dart';
+import 'package:unittest/unittest.dart';
+
+import '../jasmine_syntax.dart';
 
 main() => describe('selector', () {
 

--- a/test/tools/source_metadata_extractor_spec.dart
+++ b/test/tools/source_metadata_extractor_spec.dart
@@ -1,11 +1,12 @@
 library source_metadata_extractor_spec;
 
-import '../_specs.dart' hide Node, Element, Text, Token;
-
 import 'package:analyzer/src/generated/ast.dart';
-import 'package:angular/tools/source_metadata_extractor.dart';
-import 'package:angular/tools/source_crawler.dart';
 import 'package:angular/tools/common.dart';
+import 'package:angular/tools/source_crawler.dart';
+import 'package:angular/tools/source_metadata_extractor.dart';
+import 'package:unittest/unittest.dart';
+
+import '../jasmine_syntax.dart';
 
 main() => describe('SourceMetadataExtractor', () {
 


### PR DESCRIPTION
Fixes https://github.com/angular/angular.dart/issues/321
