### PR TITLE
The StackOverflow link refers the not existing tag angulardart.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Please file bugs and feature requests using the [Github Issues Tracker][issues].
 [docs]: http://ci.angularjs.org/view/Dart/job/angular.dart-master/javadoc/
 [tw]: https://twitter.com/angularjs
 [plus]: https://plus.google.com/+AngularJS
-[so]: http://stackoverflow.com/questions/tagged/angulardart
+[so]: http://stackoverflow.com/questions/tagged/angular.dart
 [list]: https://groups.google.com/forum/#!forum/angular-dart
 [tut]: https://github.com/angular/angular.dart.tutorial
 [pub]: http://pub.dartlang.org/packages/angular


### PR DESCRIPTION
Change the link so it links to the existing angular.dart tag
