### PR TITLE
fix(ng_model): do not save/restore selection unnecessarily

### DIFF
--- a/lib/directive/ng_model.dart
+++ b/lib/directive/ng_model.dart
@@ -101,12 +101,9 @@ abstract class _InputTextlikeDirective {
       if (value == null) value = '';
 
       var currentValue = typedValue;
-      if (value == currentValue || (value is num && currentValue is num && value.isNaN && currentValue.isNaN)) return;
-      var start = inputElement.selectionStart;
-      var end = inputElement.selectionEnd;
-      typedValue =  value;
-      inputElement.selectionStart = start;
-      inputElement.selectionEnd = end;
+      if (value != currentValue && !(value is num && currentValue is num && value.isNaN && currentValue.isNaN)) {
+        typedValue =  value;
+      }
     };
     inputElement.onChange.listen(relaxFnArgs(processValue));
     inputElement.onKeyDown.listen((e) {

--- a/test/directive/ng_model_spec.dart
+++ b/test/directive/ng_model_spec.dart
@@ -61,14 +61,16 @@ describe('ng-model', () {
       model.render('abc');
 
       expect(element.value).toEqual('abc');
+      // No update.  selectionStart/End is unchanged.
       expect(element.selectionStart).toEqual(1);
       expect(element.selectionEnd).toEqual(2);
 
       model.render('xyz');
 
+      // Value updated.  selectionStart/End changed.
       expect(element.value).toEqual('xyz');
-      expect(element.selectionStart).toEqual(1);
-      expect(element.selectionEnd).toEqual(2);
+      expect(element.selectionStart).toEqual(3);
+      expect(element.selectionEnd).toEqual(3);
     }));
   });
 
@@ -130,8 +132,8 @@ describe('ng-model', () {
       model.render('xyz');
 
       expect(element.value).toEqual('xyz');
-      expect(element.selectionStart).toEqual(1);
-      expect(element.selectionEnd).toEqual(2);
+      expect(element.selectionStart).toEqual(3);
+      expect(element.selectionEnd).toEqual(3);
     }));
   });
 
@@ -242,6 +244,8 @@ describe('ng-model', () {
 
       model.render('xyz');
 
+      // Setting the value on a textarea doesn't update the selection the way it
+      // does on input elements.  This stays unchanged.
       expect(element.value).toEqual('xyz');
       expect(element.selectionStart).toEqual(1);
       expect(element.selectionEnd).toEqual(2);


### PR DESCRIPTION
Closes #264
