### PR TITLE
Converting mock's Logger to use ListBase rather than mirrors

### DIFF
--- a/lib/mock/log.dart
+++ b/lib/mock/log.dart
@@ -35,7 +35,7 @@ class LogAttrDirective implements NgAttachAware {
  *
  *     expect(logger).toEqual(['foo', 'bar']);
  */
-class Logger implements List {
+class Logger extends ListBase {
   final List tokens = [];
 
   /**
@@ -48,5 +48,12 @@ class Logger implements List {
    */
   String result() => tokens.join('; ');
 
-  noSuchMethod(Invocation invocation) => mirror.reflect(tokens).delegate(invocation);
+
+  int get length => tokens.length;
+
+  operator [](int index) => tokens[index];
+
+  void operator []=(int index, value) { tokens[index] = value; }
+
+  void set length(int newLength) { tokens.length = newLength; }
 }

--- a/lib/mock/module.dart
+++ b/lib/mock/module.dart
@@ -1,9 +1,9 @@
 library angular.mock;
 
 import 'dart:async' as dart_async;
+import 'dart:collection' show ListBase;
 import 'dart:convert' show JSON;
 import 'dart:html';
-import 'dart:mirrors' as mirror;
 import 'package:angular/angular.dart';
 import 'package:angular/utils.dart' as utils;
 import 'package:js/js.dart' as js;


### PR DESCRIPTION
It was using noSuchMethod and mirrors, both of which have the potential to bloat dart2js code size. This change may not have any real-world impact given the number of other places which also hit mirrors and NSM, but it seems good to remove the gratuitous use of these APIs.
