### PR TITLE
For source crawler; do not fail when source file doesn't exist.

### DIFF
--- a/lib/tools/source_crawler_impl.dart
+++ b/lib/tools/source_crawler_impl.dart
@@ -31,7 +31,10 @@ class SourceCrawlerImpl implements SourceCrawler {
     while (toVisit.isNotEmpty) {
       var currentFile = toVisit.removeAt(0);
       visited.add(currentFile);
-      var currentDir = new File(currentFile).parent.path;
+      var file = new File(currentFile);
+      // Possible source file doesn't exist. For example if it is generated.
+      if (!file.existsSync()) continue;
+      var currentDir = file.parent.path;
       CompilationUnit cu = parseDartFile(currentFile);
       processImports(cu, currentDir, currentFile, visited, toVisit);
       visitor(cu);


### PR DESCRIPTION
This will allow the source crawler to be used in more situations. For example to generate a file from sources that need to use the generated file.
