### PR TITLE
chore(cleanup): Fix warnings in lib/tools

### DIFF
--- a/lib/core/parser/backend.dart
+++ b/lib/core/parser/backend.dart
@@ -308,7 +308,7 @@ class ParserBackend {
 
   zero() => ZERO;
 
-  FilterExpression filter(String filterName,
+  Expression filter(String filterName,
                          Expression leftHandSide,
                          List<Expression> parameters,
                          Function evalError) {

--- a/lib/tools/parser_generator/source.dart
+++ b/lib/tools/parser_generator/source.dart
@@ -65,13 +65,13 @@ class Source {
 
 
 class ParenthesisSource extends Source {
-  toString([String indent='']) {
+  toString([String indent='', newLine=false, sep='']) {
     return '(' + super.toString(indent + '  ', true, ',') + ')';
   }
 }
 
 class MapSource extends Source {
-  toString([String indent='']) {
+  toString([String indent='', newLine=false, sep='']) {
     return '{' + super.toString(indent + '  ', true, ',') + '}';
   }
 }
@@ -80,13 +80,13 @@ class BodySource extends Source {
   BodySource() {
     //this('');
   }
-  toString([String indent='']) {
+  toString([String indent='', newLine=false, sep='']) {
     return '{${super.toString(indent + '  ', true)}\n$indent}';
   }
 }
 
 class StatementSource extends Source {
-  toString([String indent='']) {
+  toString([String indent='', newLine=false, sep='']) {
     return '${super.toString(indent + '  ')};';
   }
 }

--- a/lib/tools/parser_getter_setter/generator.dart
+++ b/lib/tools/parser_getter_setter/generator.dart
@@ -12,6 +12,7 @@ class DartGetterSetterGen implements ParserBackend {
 
   binaryFn(left, String fn, right) => new _AST();
   unaryFn(String fn, right)  => new _AST();
+  ternaryFn(Expression cond, Expression _true, Expression _false) => new _AST();
   assignment(left, right, evalError)  => new _AST();
   multipleStatements(List statements)  => new _AST();
   arrayDeclaration(List elementFns)  => new _AST();
@@ -21,6 +22,13 @@ class DartGetterSetterGen implements ParserBackend {
   value(v) => new _AST();
   zero() => new _AST();
   functionCall(fn, fnName, List argsFn, evalError) => new _AST();
+  filter(String filterName,
+      Expression leftHandSide,
+      List<Expression> parameters,
+      Function evalError) => new _AST();
+
+  setter(String path) => throw new UnimplementedError();
+  getter(String path) => throw new UnimplementedError();
 
 
   fieldAccess(object, String field) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -4,7 +4,7 @@ packages:
   analyzer:
     description: analyzer
     source: hosted
-    version: "0.10.2"
+    version: "0.10.5"
   args:
     description: args
     source: hosted
@@ -13,10 +13,14 @@ packages:
     description: browser
     source: hosted
     version: "0.9.0"
+  collection_helpers:
+    description: collection_helpers
+    source: hosted
+    version: "0.9.1"
   di:
     description: di
     source: hosted
-    version: "0.0.28"
+    version: "0.0.29"
   html5lib:
     description: html5lib
     source: hosted
@@ -24,19 +28,19 @@ packages:
   intl:
     description: intl
     source: hosted
-    version: "0.9.0"
+    version: "0.9.1"
   js:
     description: js
     source: hosted
-    version: "0.2.0"
+    version: "0.2.1"
   logging:
     description: logging
     source: hosted
-    version: "0.9.0"
+    version: "0.9.1"
   path:
     description: path
     source: hosted
-    version: "0.9.0"
+    version: "1.0.0"
   perf_api:
     description: perf_api
     source: hosted
@@ -52,15 +56,15 @@ packages:
   stack_trace:
     description: stack_trace
     source: hosted
-    version: "0.9.0"
+    version: "0.9.1"
   unittest:
     description: unittest
     source: hosted
-    version: "0.9.0"
+    version: "0.9.1"
   unmodifiable_collection:
     description: unmodifiable_collection
     source: hosted
-    version: "0.9.0"
+    version: "0.9.1"
   utf:
     description: utf
     source: hosted


### PR DESCRIPTION
Fixes https://github.com/angular/angular.dart/issues/346

I made `Code` implement `Expression` and `DartCodeGen` and `DartGetterSetterGen` implement `ParserBacked` to eliminate the warnings, though it looks like a deeper refactoring would ultimately be better. There appears to be a viable split between creating an AST and creating callable objects. 
