### PR TITLE
Don't allow implicit returns

### DIFF
--- a/demo/todo/todo.dart
+++ b/demo/todo/todo.dart
@@ -65,6 +65,7 @@ class TodoController {
     if (key == 'newItem') {
       return newItem;
     }
+    return null;
   }
 
   add() {


### PR DESCRIPTION
Change to keep the samples in the Dart Editor clean of hint-violations, more context at:

https://codereview.chromium.org/99303007/
