### PR TITLE
Updating cookies unittests to pass under the Dart unittest test runner

### DIFF
--- a/test/core_dom/cookies_spec.dart
+++ b/test/core_dom/cookies_spec.dart
@@ -198,6 +198,11 @@ main() => describe('cookies', () {
     });
   });
 
+  beforeEach(module((Module module) {
+    var cookies = new BrowserCookies()..cookiePath = '/';
+    module.value(Cookies, new Cookies(cookies));
+  }));
+
   describe('cookies service', () {
     var cookiesService;
     beforeEach(inject((Cookies iCookies) {


### PR DESCRIPTION
I'm working on getting Angular tests running as part of Dart's standard test suite.
