### PR TITLE
Patch for tags/v0.9.3 to make it work on SDK 1.1

### DIFF
--- a/lib/core/scope.dart
+++ b/lib/core/scope.dart
@@ -774,7 +774,9 @@ _toJson(obj) {
         // work-around dartbug.com/14130
         try {
           ret = mirror.function.source;
-        } on NoSuchMethodError catch (e) {}
+        } on NoSuchMethodError catch (e) {
+        } on UnimplementedError catch (e) {
+        }
       }
       return true;
     })());
@@ -790,6 +792,7 @@ String _source(obj) {
       try {
         return "FN: ${m.function.source}";
       } on NoSuchMethodError catch (e) {
+      } on UnimplementedError catch (e) {
       }
     }
   }


### PR DESCRIPTION
Dart SDK 1.1 is shipping soon. We need to update Angular 0.9.3 to work with that somehow.

This is a patch for tags/v0.9.3 that makes the code work on SDK 1.0 and 1.1. It doesn't change the (broken) semantics of only doing a local member lookup (using either ClassMirror.members or ClassMirror.declarations), but it does use ClassMirror.instanceMembers when available (SDK 1.1 running on Dartium) which is better.

Not sure how to go about landing this and pushing out a new release (0.9.3.1?). Ideally, we can update the pub version too so all the tutorials and samples that currently use 0.9.3 automatically get the fix.
