### PR TITLE
feat(directives): Added two way databind for html5 contenteditable attri...

### DIFF
--- a/lib/directive/module.dart
+++ b/lib/directive/module.dart
@@ -58,6 +58,7 @@ class NgDirectiveModule extends Module {
     value(TextAreaDirective, null);
     value(InputSelectDirective, null);
     value(OptionValueDirective, null);
+    value(ContentEditableDirective, null);
     value(NgModel, null);
     value(NgSwitchDirective, null);
     value(NgSwitchWhenDirective, null);

--- a/lib/directive/ng_model.dart
+++ b/lib/directive/ng_model.dart
@@ -325,3 +325,25 @@ class InputRadioDirective {
     });
   }
 }
+
+/**
+ * Usage (span could be replaced with any element like p):
+ *
+ *     <span contenteditable="true" ng-model="name">
+ *
+ * This creates a two way databinding between the expression specified in
+ * ng-model and the html element in the DOM.  If the ng-model value is
+ * `null`, it is treated as equivalent to the empty string for rendering
+ * purposes.
+ */
+@NgDirective(selector: '[contenteditable=true][ng-model]')
+class ContentEditableDirective extends _InputTextlikeDirective {
+  
+  // The implementation is identical to _InputTextlikeDirective but use innerHtml instead of value
+  get typedValue => (inputElement as dynamic).innerHtml;
+  set typedValue(String value) => (inputElement as dynamic).innerHtml = (value == null) ? '' : value;
+
+  ContentEditableDirective(dom.Element inputElement, NgModel ngModel, Scope scope):
+      super(inputElement, ngModel, scope);
+
+}


### PR DESCRIPTION
Hi guys,
This is a simple implementation for data bind between html5 contentenditable atributes. First I find this thread in stack overflow: http://stackoverflow.com/questions/15108602/two-way-binding-of-contenteditable-item-inside-ng-list 
It uses AngularJs.
My first try was translate the code in stack overflow to Dart. But after I read the code on _InputTextlikeDirective in the same file, I realize that it do more checks and make the same think, so I just override the get and set for the value be the innerHtml instead of value

I also open this thread for angular dart: http://stackoverflow.com/questions/21055252/how-to-enable-databind-in-contenteditable-on-angular-dart
