### PR TITLE
fix(directives): cssUrl in NgComponent

### DIFF
--- a/lib/core/directive.dart
+++ b/lib/core/directive.dart
@@ -247,6 +247,7 @@ class NgComponent extends NgAnnotation {
       new NgComponent(
           template: this.template,
           templateUrl: this.templateUrl,
+          cssUrl: this.cssUrl,
           cssUrls: this.cssUrls,
           applyAuthorStyles: this.applyAuthorStyles,
           resetStyleInheritance: this.resetStyleInheritance,


### PR DESCRIPTION
When `cssUrls` (plural) attribute was added to `NgComponent` annotation,  `cssUrl` (singular) attribute was apparently accidentally removed from body of `cloneWithNewMap` method. 
As a result, if `NgComponent` uses annotations to bind attributes (`NgTwoWay` etc.) and `cloneWithNewMap` is used, `cssUrl` is lost during creating of new object.  

Related to #418 
