### PR TITLE
fix(generator): Avoid compile-time filter map querying when generating

### DIFF
--- a/bin/parser_generator_for_spec.dart
+++ b/bin/parser_generator_for_spec.dart
@@ -1,17 +1,9 @@
-import 'dart:io';
 import 'package:di/di.dart';
 import 'package:di/dynamic_injector.dart';
 import 'package:angular/core/module.dart';
 import 'package:angular/core/parser/parser.dart';
 import 'package:angular/tools/parser_generator/generator.dart';
 import 'package:angular/tools/parser_getter_setter/generator.dart';
-
-class NullFilterMap implements FilterMap {
-  call(name) => null;
-  Type operator[](annotation) => null;
-  forEach(fn) { }
-  annotationsFor(type) => null;
-}
 
 main(arguments) {
   var isGetter = !arguments.isEmpty;

--- a/lib/core/module.dart
+++ b/lib/core/module.dart
@@ -12,8 +12,8 @@ import 'package:angular/core/parser/parser.dart';
 import 'package:angular/core/parser/lexer.dart';
 import 'package:angular/utils.dart';
 
-import 'service.dart';
-export 'service.dart';
+import 'package:angular/core/service.dart';
+export 'package:angular/core/service.dart';
 
 part "cache.dart";
 part "directive.dart";

--- a/lib/playback/playback_http.dart
+++ b/lib/playback/playback_http.dart
@@ -8,7 +8,7 @@ import 'package:angular/core_dom/module.dart';
 import 'package:angular/core/service.dart';
 import 'package:angular/mock/module.dart' as mock;
 
-import 'playback_data.dart' as playback_data;
+import 'package:angular/playback/playback_data.dart' as playback_data;
 
 @NgInjectableService()
 class PlaybackHttpBackendConfig {

--- a/lib/tools/expression_extractor.dart
+++ b/lib/tools/expression_extractor.dart
@@ -10,8 +10,10 @@ import 'package:angular/tools/common.dart';
 
 import 'package:di/di.dart';
 import 'package:di/dynamic_injector.dart';
-import 'package:angular/tools/parser_generator/generator.dart';
+
+import 'package:angular/core/module.dart';
 import 'package:angular/core/parser/parser.dart';
+import 'package:angular/tools/parser_generator/generator.dart';
 
 main(args) {
   if (args.length < 5) {
@@ -50,9 +52,10 @@ main(args) {
 
   printer.printSrc('// Found ${expressions.length} expressions');
   Module module = new Module()
-    ..type(Parser, implementedBy: DynamicParser)
-    ..type(ParserBackend, implementedBy: DynamicParserBackend)
-    ..value(SourcePrinter, printer);
+      ..type(Parser, implementedBy: DynamicParser)
+      ..type(ParserBackend, implementedBy: DynamicParserBackend)
+      ..type(FilterMap, implementedBy: NullFilterMap)
+      ..value(SourcePrinter, printer);
   Injector injector =
       new DynamicInjector(modules: [module], allowImplicitInjection: true);
 

--- a/lib/tools/html_extractor.dart
+++ b/lib/tools/html_extractor.dart
@@ -3,9 +3,9 @@ library angular.html_parser;
 import 'package:html5lib/parser.dart';
 import 'package:html5lib/dom.dart';
 
-import 'selector.dart';
-import 'io.dart';
-import 'common.dart';
+import 'package:angular/tools/selector.dart';
+import 'package:angular/tools/io.dart';
+import 'package:angular/tools/common.dart';
 
 typedef NodeVisitor(Node node);
 

--- a/lib/tools/io_impl.dart
+++ b/lib/tools/io_impl.dart
@@ -1,7 +1,7 @@
 library angular.io_impl;
 
 import 'dart:io';
-import 'io.dart';
+import 'package:angular/tools/io.dart';
 
 class IoServiceImpl implements IoService {
 

--- a/lib/tools/parser_generator/generator.dart
+++ b/lib/tools/parser_generator/generator.dart
@@ -1,7 +1,15 @@
 library generator;
 
-import 'dart_code_gen.dart';
-import '../../core/parser/parser.dart';
+import 'package:angular/core/module.dart';
+import 'package:angular/core/parser/parser.dart';
+import 'package:angular/tools/parser_generator/dart_code_gen.dart';
+
+class NullFilterMap implements FilterMap {
+  call(name) => null;
+  Type operator[](annotation) => null;
+  forEach(fn) { }
+  annotationsFor(type) => null;
+}
 
 class SourcePrinter {
   printSrc(src) {

--- a/lib/tools/source_crawler_impl.dart
+++ b/lib/tools/source_crawler_impl.dart
@@ -2,7 +2,7 @@ library angular.source_crawler_impl;
 
 import 'dart:io';
 import 'package:analyzer/analyzer.dart';
-import 'source_crawler.dart';
+import 'package:angular/tools/source_crawler.dart';
 
 const String PACKAGE_PREFIX = 'package:';
 

--- a/lib/tools/source_metadata_extractor.dart
+++ b/lib/tools/source_metadata_extractor.dart
@@ -2,9 +2,9 @@ library angular.source_metadata_extractor ;
 
 import 'package:analyzer/src/generated/ast.dart';
 
-import 'source_crawler.dart';
-import '../utils.dart';
-import 'common.dart';
+import 'package:angular/tools/source_crawler.dart';
+import 'package:angular/tools/common.dart';
+import 'package:angular/utils.dart';
 
 const String _COMPONENT = '-component';
 const String _DIRECTIVE = '-directive';

--- a/lib/tools/template_cache_generator.dart
+++ b/lib/tools/template_cache_generator.dart
@@ -5,7 +5,7 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:analyzer/src/generated/ast.dart';
-import 'source_crawler_impl.dart';
+import 'package:angular/tools/source_crawler_impl.dart';
 
 const String PACKAGE_PREFIX = 'package:';
 const String DART_PACKAGE_PREFIX = 'dart:';


### PR DESCRIPTION
Avoid compile-time filter map querying when generating the static parser.

This fixes https://github.com/angular/angular.dart/issues/432.

Also consistenly load libraries through the package root to avoid getting in
trouble if the same library is loaded through different URIs.
