### PR TITLE
fix(tools): correct selector regexp for ng-attr-*

### DIFF
--- a/lib/tools/selector.dart
+++ b/lib/tools/selector.dart
@@ -11,7 +11,7 @@ class ContainsSelector {
   }
 }
 
-RegExp _SELECTOR_REGEXP = new RegExp(r'^(?:([\w\-]+)|(?:\.([\w\-]+))|(?:\[([\w\-]+)(?:=([^\]]*))?\]))');
+RegExp _SELECTOR_REGEXP = new RegExp(r'^(?:([\w\-]+)|(?:\.([\w\-]+))|(?:\[([\w\-\*]+)(?:=([^\]]*))?\]))');
 RegExp _COMMENT_COMPONENT_REGEXP = new RegExp(r'^\[([\w\-]+)(?:\=(.*))?\]$');
 RegExp _CONTAINS_REGEXP = new RegExp(r'^:contains\(\/(.+)\/\)$'); //
 RegExp _ATTR_CONTAINS_REGEXP = new RegExp(r'^\[\*=\/(.+)\/\]$'); //


### PR DESCRIPTION
This was presumably meant to be part of aeb5538e2d4634b966467a4f90f0a5ac8b63dd4e.
