### PR TITLE
[WIP]refactor(directives): simplify some code

### DIFF
--- a/lib/core/directive.dart
+++ b/lib/core/directive.dart
@@ -202,10 +202,8 @@ class NgComponent extends NgAnnotation {
   final List<String> cssUrls;
 
   List<String> get allCssUrls {
-    if (cssUrls == null && cssUrl == null) return null;
-    if (cssUrls == null && cssUrl != null) return [cssUrl];
-    if (cssUrls != null && cssUrl == null) return cssUrls;
-    if (cssUrls != null && cssUrl != null) return [cssUrl]..addAll(cssUrls);
+    List<String> urls = cssUrl == null ? [] : [cssUrl];
+    return cssUrls == null ? urls : urls..addAll(cssUrls);
   }
 
 /**


### PR DESCRIPTION
This change was part of #440 but didn't make it into master.

However I would like to propose this change:
- `cssUrl` and `cssUrls` should be protected , ie `_` prefixed
- drop the `allCssUrls` getter,
- add a `cssUrls` getter (which would be the legacy `allCssUrls`).

That would be much cleaner but a BC break (easy to fix w/ find & replace).

Thoughts ?
