### PR TITLE
Fixing some dart2js compilation issues for todo demo

### DIFF
--- a/demo/todo/web/todo.dart
+++ b/demo/todo/web/todo.dart
@@ -43,8 +43,7 @@ class NoServerController implements ServerController {
 
 
 @NgDirective(
-  selector: '[todo-controller]',
-  publishAs: 'todo'
+  selector: '[todo-controller]'
 )
 class TodoController {
   List<Item> items;

--- a/lib/angular.dart
+++ b/lib/angular.dart
@@ -39,7 +39,7 @@ import 'package:di/dynamic_injector.dart';
     'angular.core.parser.lexer',
     'perf_api',
     'List',
-    'NodeTreeSanitizer',
+    'dart.dom.html.NodeTreeSanitizer',
 ],
 metaTargets: const[
   'NgInjectableService',


### PR DESCRIPTION
One is that the publishAs parameter was removed from NgDirective constructor with (https://github.com/angular/angular.dart/commit/c48433e0350d4b374614eef8a0c9036805535dcb)

The other is a warning from the dart2js compiler that 'NodeTreeSanitizer' is not known- strings in @MirrorsUsed use the full lib name (but not for core types?)
