### PR TITLE
fix(parser): Make sure to run the parser tests using the generated hybrid parser.

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-export DART_SDK=`which dart | sed -e 's/\/dart\-sdk\/.*$/\/dart-sdk/'`
-
 # OS-specific Dartium path defaults
 case $( uname -s ) in
   Darwin)

--- a/test/core/parser/generated_getter_setter_spec.dart
+++ b/test/core/parser/generated_getter_setter_spec.dart
@@ -10,6 +10,6 @@ main() {
       module.type(Parser, implementedBy: DynamicParser);
       module.type(ClosureMap, implementedBy: StaticClosureMap);
     }));
-    //parser_spec.main();
+    parser_spec.main();
   });
 }


### PR DESCRIPTION
Computing the DART_SDK based on the location of the dart executable is often wrong (in particular if you have forwarding scripts). It's better to let the system compute the SDK location based on the actual location of the Dart VM (Platform.executable).
