### PR TITLE
add default type attribute for input element

### DIFF
--- a/lib/core_dom/selector.dart
+++ b/lib/core_dom/selector.dart
@@ -254,6 +254,11 @@ DirectiveSelector directiveSelectorFactory(DirectiveMap directives) {
         String nodeName = element.tagName.toLowerCase();
         Map<String, String> attrs = {};
 
+        // Set default attribute
+        if (nodeName == 'input' && !element.attributes.containsKey('type')) {
+          element.attributes['type'] = 'text';
+        }
+
         // Select node
         partialSelection = elementSelector.selectNode(directiveRefs, partialSelection, element, nodeName);
 

--- a/test/directive/ng_model_spec.dart
+++ b/test/directive/ng_model_spec.dart
@@ -136,6 +136,74 @@ describe('ng-model', () {
     }));
   });
 
+  describe('no type attribute', () {
+    it('should be set "text" as default value for "type" attribute', inject(() {
+      _.compile('<input ng-model="model">');
+      _.rootScope.$digest();
+      expect((_.rootElement as dom.InputElement).attributes['type']).toEqual('text');
+    }));
+
+    it('should update input value from model', inject(() {
+      _.compile('<input ng-model="model">');
+      _.rootScope.$digest();
+
+      expect((_.rootElement as dom.InputElement).value).toEqual('');
+
+      _.rootScope.$apply('model = "misko"');
+      expect((_.rootElement as dom.InputElement).value).toEqual('misko');
+    }));
+
+    it('should render null as the empty string', inject(() {
+      _.compile('<input ng-model="model">');
+      _.rootScope.$digest();
+
+      expect((_.rootElement as dom.InputElement).value).toEqual('');
+
+      _.rootScope.$apply('model = null');
+      expect((_.rootElement as dom.InputElement).value).toEqual('');
+    }));
+
+    it('should update model from the input value', inject(() {
+      _.compile('<input ng-model="model" probe="p">');
+      Probe probe = _.rootScope.p;
+      var ngModel = probe.directive(NgModel);
+      InputElement inputElement = probe.element;
+
+      inputElement.value = 'abc';
+      _.triggerEvent(inputElement, 'change');
+      expect(_.rootScope.model).toEqual('abc');
+
+      inputElement.value = 'def';
+      var input = probe.directive(InputTextLikeDirective);
+      input.processValue();
+      expect(_.rootScope.model).toEqual('def');
+    }));
+
+    it('should write to input only if value is different', inject(() {
+      var scope = _.rootScope;
+      var element = new dom.InputElement();
+      var model = new NgModel(scope, new NodeAttrs(new DivElement()), element, new NgNullForm());
+      dom.querySelector('body').append(element);
+      var input = new InputTextLikeDirective(element, model, scope);
+
+      element.value = 'abc';
+      element.selectionStart = 1;
+      element.selectionEnd = 2;
+
+      model.render('abc');
+
+      expect(element.value).toEqual('abc');
+      expect(element.selectionStart).toEqual(1);
+      expect(element.selectionEnd).toEqual(2);
+
+      model.render('xyz');
+
+      expect(element.value).toEqual('xyz');
+      expect(element.selectionStart).toEqual(3);
+      expect(element.selectionEnd).toEqual(3);
+    }));
+  });
+
   describe('type="checkbox"', () {
     it('should update input value from model', inject((Scope scope) {
       var element = _.compile('<input type="checkbox" ng-model="model">');


### PR DESCRIPTION
Now &lt;input ng-model="myModel" /> does not work because there is not any type attribute. This patch makes this work.
