### PR TITLE
Depend on shadow_dom so we can use the polyfill

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,3 +21,4 @@ dependencies:
   perf_api: '>=0.0.8 <0.1.0'
   route_hierarchical: '>=0.4.7 <0.5.0'
   unittest: '>=0.8.7 <0.10.0'
+  shadow_dom: '>=0.9.1 <1.0.0'


### PR DESCRIPTION
We need this to run on Firefox, for example.
