### PR TITLE
Fix #395: <input type=radio ng-mode="model" value={{value}}> Does not work

### DIFF
--- a/lib/core_dom/selector.dart
+++ b/lib/core_dom/selector.dart
@@ -254,6 +254,12 @@ DirectiveSelector directiveSelectorFactory(DirectiveMap directives) {
         String nodeName = element.tagName.toLowerCase();
         Map<String, String> attrs = {};
 
+        // The ng-model attribute must be interpreted at last.
+        if (element.attributes.containsKey('ng-model')) {
+          var value = element.attributes.remove('ng-model');
+          element.attributes['ng-model'] = value;
+        }
+
         // Select node
         partialSelection = elementSelector.selectNode(directiveRefs, partialSelection, element, nodeName);
 


### PR DESCRIPTION
I know this patch is quite dirty but it works anyway.
