### PR TITLE
Moving @MirrorsUsed out of angular.dart

### DIFF
--- a/demo/helloworld/helloworld.dart
+++ b/demo/helloworld/helloworld.dart
@@ -1,11 +1,14 @@
+library angular.demo.hello_world;
+
 import 'package:angular/angular.dart';
+import 'package:angular/dart2js_mirrors.dart';
 
 // This annotation allows Dart to shake away any classes
 // not used from Dart code nor listed in another @MirrorsUsed.
 //
 // If you create classes that are referenced from the Angular
 // expressions, you must include a library target in @MirrorsUsed.
-@MirrorsUsed(override: '*')
+@MirrorsUsed(targets: const['angular.demo.hello_world'])
 import 'dart:mirrors';
 
 main() {

--- a/demo/todo/pubspec.lock
+++ b/demo/todo/pubspec.lock
@@ -51,6 +51,10 @@ packages:
     description: route_hierarchical
     source: hosted
     version: "0.4.10"
+  shadow_dom:
+    description: shadow_dom
+    source: hosted
+    version: "0.9.1"
   source_maps:
     description: source_maps
     source: hosted

--- a/demo/todo/web/main.dart
+++ b/demo/todo/web/main.dart
@@ -1,5 +1,6 @@
 import 'package:di/di.dart';
 import 'package:angular/angular.dart';
+import 'package:angular/dart2js_mirrors.dart';
 import 'package:angular/playback/playback_http.dart';
 import 'todo.dart';
 
@@ -7,8 +8,7 @@ import 'dart:html';
 
 // Everything in the 'todo' library should be preserved by MirrorsUsed
 @MirrorsUsed(
-    targets: const['todo'],
-    override: '*')
+    targets: const['todo'])
 import 'dart:mirrors';
 
 main() {

--- a/lib/angular.dart
+++ b/lib/angular.dart
@@ -15,42 +15,6 @@ import 'dart:js' as js;
 import 'package:di/di.dart';
 import 'package:di/dynamic_injector.dart';
 
-/**
- * If you are writing code accessed from Angular expressions, you must include
- * your own @MirrorsUsed annotation or ensure that everything is tagged with
- * the Ng annotations.
- *
- * All programs should also include a @MirrorsUsed(override: '*') which
- * tells the compiler that only the explicitly listed libraries will
- * be reflected over.
- *
- * This is a short-term fix until we implement a transformer-based solution
- * which does not rely on mirrors.
- */
-@MirrorsUsed(targets: const [
-    'angular',
-    'angular.core',
-    'angular.core.dom',
-    'angular.filter',
-    'angular.perf',
-    'angular.directive',
-    'angular.routing',
-    'angular.core.parser.Parser',
-    'angular.core.parser.dynamic_parser',
-    'angular.core.parser.lexer',
-    'perf_api',
-    List,
-    dom.NodeTreeSanitizer,
-],
-metaTargets: const [
-    NgInjectableService,
-    NgDirective,
-    NgController,
-    NgComponent,
-    NgFilter
-])
-import 'dart:mirrors' show MirrorsUsed;
-
 import 'package:angular/core/module.dart';
 import 'package:angular/core_dom/module.dart';
 import 'package:angular/directive/module.dart';
@@ -69,3 +33,4 @@ export 'package:angular/routing/module.dart';
 
 part 'bootstrap.dart';
 part 'introspection.dart';
+

--- a/lib/dart2js_mirrors.dart
+++ b/lib/dart2js_mirrors.dart
@@ -1,0 +1,57 @@
+/**
+ * An import that specifies the minimal set of mirrors used needed
+ * for Angular applications.
+ *
+ * This is only needed if the application is relying on mirrors at runtime and
+ * not using generated expressions and a static injector (experimental at this
+ * time).
+ *
+ * To use this, just include this file anywhere in your project (no further
+ * steps).
+ */
+library angular.dart2js_mirrors;
+
+import 'dart:html' as dom;
+import 'package:angular/angular.dart';
+import 'package:angular/core/service.dart';
+
+/**
+ * If you are writing code accessed from Angular expressions, you must include
+ * your own @MirrorsUsed annotation or ensure that everything is tagged with
+ * the Ng annotations.
+ *
+ * This is a short-term fix until we implement a transformer-based solution
+ * which does not rely on mirrors.
+ */
+@MirrorsUsed(targets: const [
+    'angular',
+    'angular.core',
+    'angular.core.dom',
+    'angular.filter',
+    'angular.perf',
+    'angular.directive',
+    'angular.routing',
+    'angular.core.parser.Parser',
+    'angular.core.parser.dynamic_parser',
+    'angular.core.parser.lexer',
+    'perf_api',
+    List,
+    dom.NodeTreeSanitizer,
+],
+metaTargets: const [
+    NgInjectableService,
+    NgDirective,
+    NgController,
+    NgComponent,
+    NgFilter
+],
+override: const [
+    'angular.core',
+    'angular.core.parser.eval_access',
+    'angular.core.parser.eval_calls',
+    'angular.directive',
+    'unittest.mock',
+    'di.src.reflected_type',
+    'mirrors', // di.mirrors
+])
+import 'dart:mirrors' show MirrorsUsed, MirrorSystem;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,6 +49,10 @@ packages:
     description: route_hierarchical
     source: hosted
     version: "0.4.10"
+  shadow_dom:
+    description: shadow_dom
+    source: hosted
+    version: "0.9.1"
   source_maps:
     description: source_maps
     source: hosted


### PR DESCRIPTION
The issue is that types added via @MirrorsUsed can never be removed, so these cannot be dropped if users use the static generators.

This moves the @MirrorsUsed into an optional import, which means that all of the samples need to be updated to explicitly include this.

The benefit is that we can then migrate over to the static generators without having a large breaking change.

I also added explicit overrides so the override: '*' is not needed.
