### PR TITLE
Fixed copy-paste error in `CurrencyFilter` class comment

### DIFF
--- a/lib/filter/currency.dart
+++ b/lib/filter/currency.dart
@@ -7,7 +7,7 @@ part of angular.filter;
  *
  * Usage:
  *
- *     {{ number_expression | number[:fractionSize] }}
+ *     {{ number_expression | currency[:fractionSize] }}
  *
  */
 @NgFilter(name:'currency')


### PR DESCRIPTION
The currency filter class comment referred to the `number` filter name.
