### PR TITLE
`NgRepeatDirective` class comment example fixed

### DIFF
--- a/lib/directive/ng_repeat.dart
+++ b/lib/directive/ng_repeat.dart
@@ -71,8 +71,8 @@ class _Row {
  *
  * # Example:
  *
- *     <ul ng-repeat="item in ['foo', 'bar', 'baz']">
- *       <li>{{$item}}</li>
+ *     <ul>
+ *       <li ng-repeat="item in ['foo', 'bar', 'baz']">{{item}}</li>
  *     </ul>
  */
 


### PR DESCRIPTION
- Moved the `ng-repeat` attribute from the `ul` to the `li`, since
  that is more typical.
- Removed `$` prefix from local `ng-repeat` variable `item`.
