### PR TITLE
docs(template_cache_generator): Fix console output argument.

### DIFF
--- a/lib/tools/template_cache_generator.dart
+++ b/lib/tools/template_cache_generator.dart
@@ -48,7 +48,7 @@ main(args) {
   print('output: $output');
   print('outputLibrary: $outputLibrary');
   print('packageRoots: $packageRoots');
-  print('url rewritters: ' + args[4]);
+  print('url rewritters: ' + args[5]);
   print('blacklistedClasses: ' + blacklistedClasses.join(', '));
 
 


### PR DESCRIPTION
This changes the template_cache_generator output to correctly output the url rewriters instead of the packageRoots.
