### PR TITLE
fix(ngRepeat): implement track by support

### DIFF
--- a/test/directive/ng_repeat_spec.dart
+++ b/test/directive/ng_repeat_spec.dart
@@ -114,7 +114,7 @@ main() {
       });
 
 
-      xit(r'should iterate over an array of primitives', () {
+      it(r'should iterate over an array of primitives', () {
         element = $compile(
             r'<ul>' +
                 r'<li ng-repeat="item in items track by $index">{{item}};</li>' +


### PR DESCRIPTION
Grab and parse the track by expression if given, and use it to
track the objects.

Closes #277
