### PR TITLE
docs(CONTRIBUTING.md): use run-test.sh instead of grunt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ Before you submit your pull request consider the following guidelines:
 * Build your changes locally to ensure all the tests pass
 
     ```shell
-    grunt test
+    ./run-test.sh
     ```
 
 * Push your branch to Github:


### PR DESCRIPTION
I'm not sure it's a correct fix but I cannot find any Gruntfile. 
