### PR TITLE
feat(routing): use longer path first

### DIFF
--- a/lib/routing/routing.dart
+++ b/lib/routing/routing.dart
@@ -18,7 +18,9 @@ class ViewFactory {
       _configure(locationService.router.root, config);
 
   _configure(Route route, Map<String, NgRouteCfg> config) {
-    config.forEach((name, cfg) {
+    (config.keys.toList()..sort((n1, n2) =>
+        (config[n2].path + '/').compareTo(config[n1].path + '/'))).forEach((name) {
+      var cfg = config[name];
       var moduledCalled = false;
       List<Module> newModules;
       route.addRoute(

--- a/test/routing/routing_spec.dart
+++ b/test/routing/routing_spec.dart
@@ -144,6 +144,52 @@ main() {
       expect(router.activePath.first.name).toBe('bar');
     }));
 
+    it('should use longer path first if their prefix are the same', async(() {
+      var counters = {
+        'foo': 0,
+        'fooparam': 0,
+        'bar': 0,
+        'barparam': 0,
+      };
+      initRouter((Router router, ViewFactory views) {
+        views.configure({
+          'fooparam': ngRoute(
+              path: '/foo/:param',
+              enter: (_) => counters['fooparam']++
+          ),
+          'foo': ngRoute(
+              path: '/foo',
+              enter: (_) => counters['foo']++
+          ),
+          'bar': ngRoute(
+              path: '/bar',
+              enter: (_) => counters['bar']++
+          ),
+          'barparam': ngRoute(
+              path: '/bar/:param',
+              enter: (_) => counters['barparam']++
+          )
+        });
+      });
+
+      router.route('/foo/bar');
+      microLeap();
+      expect(counters, equals({
+        'foo': 0,
+        'fooparam': 1,
+        'bar': 0,
+        'barparam': 0,
+      }));
+
+      router.route('/bar/buz');
+      microLeap();
+      expect(counters, equals({
+        'foo': 0,
+        'fooparam': 1,
+        'bar': 0,
+        'barparam': 1,
+      }));
+    }));
 
     it('should call enter callback and show the view when routed', async(() {
       int enterCount = 0;


### PR DESCRIPTION
This patch makes the following example (from the angular.js tutorial
step 7) work.

``` dart
views.configure({
  'phonesList': ngRoute(
    'path': 'phones',
    'enter': (\_) => ...
  ),
  'phoneDetail': ngRoute(
    'path': 'phones/:phoneId',
    'enter': (\_) => ...
  )
});
```
