### PR TITLE
Slight refactor of expression extractor to make it easier to drive from pub transformers

### DIFF
--- a/lib/tools/expression_extractor.dart
+++ b/lib/tools/expression_extractor.dart
@@ -26,11 +26,11 @@ main(args) {
   var packageRoots =
       (args.length < 6) ? [Platform.packageRoot] : args.sublist(5);
   var sourceCrawler = new SourceCrawlerImpl(packageRoots);
-  var sourceMetadataExtractor = new SourceMetadataExtractor(sourceCrawler);
+  var sourceMetadataExtractor = new SourceMetadataExtractor();
   List<DirectiveInfo> directives =
-      sourceMetadataExtractor.gatherDirectiveInfo(args[0]);
-  var htmlExtractor = new HtmlExpressionExtractor(directives, ioService);
-  htmlExtractor.crawl(args[1]);
+      sourceMetadataExtractor.gatherDirectiveInfo(args[0], sourceCrawler);
+  var htmlExtractor = new HtmlExpressionExtractor(directives);
+  htmlExtractor.crawl(args[1], ioService);
 
   var expressions = htmlExtractor.expressions;
   expressions.add('null');

--- a/lib/tools/html_extractor.dart
+++ b/lib/tools/html_extractor.dart
@@ -14,27 +14,26 @@ RegExp _NG_REPEAT_SYNTAX = new RegExp(r'^\s*(.+)\s+in\s+(.*?)\s*(\s+track\s+by\s
 
 class HtmlExpressionExtractor {
   List<DirectiveInfo> directiveInfos;
-  IoService ioService;
 
-  HtmlExpressionExtractor(this.directiveInfos, this.ioService);
-
-  Set<String> expressions = new Set<String>();
-
-  void crawl(root) {
-    ioService.visitFs(root, (String file) {
-      if (!file.endsWith('.html')) return;
-
-      _parseHtml(ioService.readAsStringSync(file));
-    });
+  HtmlExpressionExtractor(this.directiveInfos) {
     for (DirectiveInfo directiveInfo in directiveInfos) {
       expressions.addAll(directiveInfo.expressions);
       if (directiveInfo.template != null) {
-        _parseHtml(directiveInfo.template);
+        parseHtml(directiveInfo.template);
       }
     }
   }
 
-  void _parseHtml(String html) {
+  Set<String> expressions = new Set<String>();
+
+  void crawl(String root, IoService ioService) {
+    ioService.visitFs(root, (String file) {
+      if (!file.endsWith('.html')) return;
+      parseHtml(ioService.readAsStringSync(file));
+    });
+  }
+
+  void parseHtml(String html) {
     var document = parse(html);
     visitNodes([document], (Node node) {
       if (matchesNode(node, r'[*=/{{.*}}/]')) {

--- a/lib/tools/source_metadata_extractor.dart
+++ b/lib/tools/source_metadata_extractor.dart
@@ -20,16 +20,15 @@ const Map<String, String> _attrAnnotationsToSpec = const {
 };
 
 class SourceMetadataExtractor {
-  SourceCrawler sourceCrawler;
   DirectiveMetadataCollectingVisitor metadataVisitor;
 
-  SourceMetadataExtractor(this.sourceCrawler, [ this.metadataVisitor ]) {
+  SourceMetadataExtractor([ this.metadataVisitor ]) {
     if (metadataVisitor == null) {
       metadataVisitor = new DirectiveMetadataCollectingVisitor();
     }
   }
 
-  List<DirectiveInfo> gatherDirectiveInfo(root) {
+  List<DirectiveInfo> gatherDirectiveInfo(root, SourceCrawler sourceCrawler) {
     sourceCrawler.crawl(root, metadataVisitor);
 
     List<DirectiveInfo> directives = <DirectiveInfo>[];

--- a/test/io/expression_extractor_spec.dart
+++ b/test/io/expression_extractor_spec.dart
@@ -20,12 +20,12 @@ main() => describe('expression_extractor', () {
 
     IoService ioService = new IoServiceImpl();
     var sourceCrawler = new SourceCrawlerImpl(['packages/']);
-    var sourceMetadataExtractor = new SourceMetadataExtractor(sourceCrawler);
+    var sourceMetadataExtractor = new SourceMetadataExtractor();
     List<DirectiveInfo> directives =
         sourceMetadataExtractor
-            .gatherDirectiveInfo('test/io/test_files/main.dart');
-    var htmlExtractor = new HtmlExpressionExtractor(directives, ioService);
-    htmlExtractor.crawl('test/io/test_files/');
+            .gatherDirectiveInfo('test/io/test_files/main.dart', sourceCrawler);
+    var htmlExtractor = new HtmlExpressionExtractor(directives);
+    htmlExtractor.crawl('test/io/test_files/', ioService);
 
     var expressions = htmlExtractor.expressions;
     expect(expressions, unorderedEquals([

--- a/test/io/source_metadata_extractor_spec.dart
+++ b/test/io/source_metadata_extractor_spec.dart
@@ -9,10 +9,10 @@ import 'package:unittest/unittest.dart';
 main() => describe('source_metadata_extractor', () {
   it('should extract all attribute mappings including annotations', () {
     var sourceCrawler = new SourceCrawlerImpl(['packages/']);
-    var sourceMetadataExtractor = new SourceMetadataExtractor(sourceCrawler);
+    var sourceMetadataExtractor = new SourceMetadataExtractor();
     List<DirectiveInfo> directives =
         sourceMetadataExtractor
-            .gatherDirectiveInfo('test/io/test_files/main.dart');
+            .gatherDirectiveInfo('test/io/test_files/main.dart', sourceCrawler);
 
     expect(directives, hasLength(2));
 

--- a/test/tools/html_extractor_spec.dart
+++ b/test/tools/html_extractor_spec.dart
@@ -16,8 +16,8 @@ main() => describe('html_extractor', () {
       '''
     });
 
-    var extractor = new HtmlExpressionExtractor([], ioService);
-    extractor.crawl('/');
+    var extractor = new HtmlExpressionExtractor([]);
+    extractor.crawl('/', ioService);
     expect(extractor.expressions.toList()..sort(),
         equals(['aux', 'ctrl.bar']));
   });
@@ -29,8 +29,8 @@ main() => describe('html_extractor', () {
       '''
     });
 
-    var extractor = new HtmlExpressionExtractor([], ioService);
-    extractor.crawl('/');
+    var extractor = new HtmlExpressionExtractor([]);
+    extractor.crawl('/', ioService);
     expect(extractor.expressions.toList()..sort(),
         equals(['aux', 'ctrl.bar']));
   });
@@ -42,8 +42,8 @@ main() => describe('html_extractor', () {
       '''
     });
 
-    var extractor = new HtmlExpressionExtractor([], ioService);
-    extractor.crawl('/');
+    var extractor = new HtmlExpressionExtractor([]);
+    extractor.crawl('/', ioService);
     expect(extractor.expressions.toList()..sort(),
         equals(['ctrl.bar']));
   });
@@ -53,8 +53,8 @@ main() => describe('html_extractor', () {
 
     var extractor = new HtmlExpressionExtractor([
       new DirectiveInfo('', [], ['foo', 'bar'])
-    ], ioService);
-    extractor.crawl('/');
+    ]);
+    extractor.crawl('/', ioService);
     expect(extractor.expressions.toList()..sort(),
         equals(['bar', 'foo']));
   });
@@ -68,8 +68,8 @@ main() => describe('html_extractor', () {
 
     var extractor = new HtmlExpressionExtractor([
       new DirectiveInfo('foo', ['bar'])
-    ], ioService);
-    extractor.crawl('/');
+    ]);
+    extractor.crawl('/', ioService);
     expect(extractor.expressions.toList()..sort(),
         equals(['ctrl.baz']));
   });
@@ -83,8 +83,8 @@ main() => describe('html_extractor', () {
 
     var extractor = new HtmlExpressionExtractor([
       new DirectiveInfo('[ng-repeat]', ['ng-repeat'])
-    ], ioService);
-    extractor.crawl('/');
+    ]);
+    extractor.crawl('/', ioService);
     // Basically we don't want to extract "foo in ctrl.bar".
     expect(extractor.expressions.toList()..sort(),
         equals(['ctrl.bar']));

--- a/test/tools/source_metadata_extractor_spec.dart
+++ b/test/tools/source_metadata_extractor_spec.dart
@@ -119,8 +119,8 @@ flattenList(list, map) => list.map(map).fold([], (prev, exprs) =>
 List<DirectiveInfo> extractDirectiveInfo(List<DirectiveMetadata> metadata) {
   var sourceCrawler = new MockSourceCrawler();
   var metadataCollector = new MockDirectiveMetadataCollectingVisitor(metadata);
-  var extractor = new SourceMetadataExtractor(sourceCrawler, metadataCollector);
-  return extractor.gatherDirectiveInfo('');
+  var extractor = new SourceMetadataExtractor(metadataCollector);
+  return extractor.gatherDirectiveInfo('', sourceCrawler);
 }
 
 class MockDirectiveMetadataCollectingVisitor


### PR DESCRIPTION
Primary change is exposing parseHtml on html_extractor to allow externally driving it rather than using a crawler.
