### PR TITLE
fix(generator): remove invalid sort on elements

### DIFF
--- a/lib/tools/template_cache_generator.dart
+++ b/lib/tools/template_cache_generator.dart
@@ -175,7 +175,6 @@ class TemplateCollectingVisitor {
         var paramName = namedArg.name.label.name;
         if (paramName == 'preCacheUrls') {
           assertList(namedArg.expression).elements
-            ..sort()
             ..forEach((expression) =>
                 cacheUris.add(assertString(expression).stringValue));
         }


### PR DESCRIPTION
cacheUris are sorted later.  sorting the elements can be invalid (e.g.
SimpleStringLiteral has == but no compareTo)
