### PR TITLE
fix(scope): use element comparison for Iterable when computing changes

### DIFF
--- a/lib/core/scope.dart
+++ b/lib/core/scope.dart
@@ -372,7 +372,7 @@ class Scope implements Map {
       $watchCollectionWatch = (_) {
         newValue = objGetter(this, _filters);
 
-        if (newValue is! Map && newValue is! List) {
+        if (newValue is! Map && newValue is! Iterable) {
           if (!_identical(oldValue, newValue)) {
             oldValue = newValue;
             changeDetected++;

--- a/test/core/scope_spec.dart
+++ b/test/core/scope_spec.dart
@@ -1077,6 +1077,15 @@ main() {
         log = [];
         $rootScope.$digest();
         expect(log).toEqual(['["b",[],{}]']);
+
+        $rootScope.obj = _toJsonableIterable(['a']);
+        log = [];
+        $rootScope.$digest();
+        expect(log).toEqual(['["a"]']);
+
+        $rootScope.obj = _toJsonableIterable(['a']);
+        $rootScope.$digest();
+        expect(log).toEqual(['["a"]']);
       });
 
 


### PR DESCRIPTION
Use element comparison instead of reference comparison when observing changes to Iterables in a scope.
