### PR TITLE
fix(ng-attr): remove camel-cased dom attributes

### DIFF
--- a/lib/core_dom/directive.dart
+++ b/lib/core_dom/directive.dart
@@ -25,14 +25,13 @@ class NodeAttrs {
   NodeAttrs(this.element);
 
   operator [](String attributeName) =>
-      element.attributes[snakecase(attributeName, '-')];
+      element.attributes[attributeName];
 
   operator []=(String attributeName, String value) {
-    var snakeName = snakecase(attributeName, '-');
     if (value == null) {
-      element.attributes.remove(snakeName);
+      element.attributes.remove(attributeName);
     } else {
-      element.attributes[snakeName] = value;
+      element.attributes[attributeName] = value;
     }
     if (_observers != null && _observers.containsKey(attributeName)) {
       _observers[attributeName].forEach((fn) => fn(value));
@@ -56,14 +55,14 @@ class NodeAttrs {
   }
 
   void forEach(void f(String k, String v)) {
-    element.attributes.forEach((k, v) => f(camelcase(k), v));
+    element.attributes.forEach(f);
   }
 
   bool containsKey(String attributeName) =>
-      element.attributes.containsKey(snakecase(attributeName, '-'));
+      element.attributes.containsKey(attributeName);
 
   Iterable<String> get keys =>
-      element.attributes.keys.map((name) => camelcase(name));
+      element.attributes.keys;
 }
 
 /**

--- a/lib/directive/ng_bind_html.dart
+++ b/lib/directive/ng_bind_html.dart
@@ -16,7 +16,7 @@ part of angular.directive;
  */
 @NgDirective(
   selector: '[ng-bind-html]',
-  map: const {'ngBindHtml': '=>value'})
+  map: const {'ng-bind-html': '=>value'})
 class NgBindHtmlDirective {
   final dom.Element element;
   final dom.NodeValidator validator;

--- a/lib/directive/ng_src_boolean.dart
+++ b/lib/directive/ng_src_boolean.dart
@@ -94,11 +94,12 @@ class NgAttributeDirective implements NgAttachAware {
   NgAttributeDirective(this._attrs);
 
   void attach() {
+    String ngAttrPrefix = 'ng-attr-';
     _attrs.forEach((key, value) {
-      if (key.startsWith('ngAttr')) {
-        var newKey = key.substring(6);
+      if (key.startsWith(ngAttrPrefix)) {
+        var newKey = key.substring(ngAttrPrefix.length);
         _attrs[newKey] = value;
-        _attrs.observe(snakecase(key), (newValue) => _attrs[newKey] = newValue );
+        _attrs.observe(key, (newValue) => _attrs[newKey] = newValue );
       }
     });
   }

--- a/test/core_dom/directive_spec.dart
+++ b/test/core_dom/directive_spec.dart
@@ -16,8 +16,8 @@ main() {
 
     it('should transform names to camel case', () {
       expect(nodeAttrs['foo']).toEqual('bar');
-      expect(nodeAttrs['fooBar']).toEqual('baz');
-      expect(nodeAttrs['fooBarBaz']).toEqual('foo');
+      expect(nodeAttrs['foo-bar']).toEqual('baz');
+      expect(nodeAttrs['foo-bar-baz']).toEqual('foo');
     });
 
     it('should return null for unexistent attributes', () {
@@ -27,18 +27,18 @@ main() {
     it('should provide a forEach function to iterate over attributes', () {
       Map<String, String> attrMap = new Map();
       nodeAttrs.forEach((k, v) => attrMap[k] = v);
-      expect(attrMap).toEqual({'foo': 'bar', 'fooBar': 'baz', 'fooBarBaz': 'foo'});
+      expect(attrMap).toEqual({'foo': 'bar', 'foo-bar': 'baz', 'foo-bar-baz': 'foo'});
     });
 
     it('should provide a contains method', () {
       expect(nodeAttrs.containsKey('foo')).toEqual(true);
-      expect(nodeAttrs.containsKey('fooBar')).toEqual(true);
-      expect(nodeAttrs.containsKey('fooBarBaz')).toEqual(true);
-      expect(nodeAttrs.containsKey('barFoo')).toEqual(false);
+      expect(nodeAttrs.containsKey('foo-bar')).toEqual(true);
+      expect(nodeAttrs.containsKey('foo-bar-baz')).toEqual(true);
+      expect(nodeAttrs.containsKey('bar-foo')).toEqual(false);
     });
 
     it('should return the attribute names', () {
-      expect(nodeAttrs.keys.toList()..sort()).toEqual(['foo', 'fooBar', 'fooBarBaz']);
+      expect(nodeAttrs.keys.toList()..sort()).toEqual(['foo', 'foo-bar', 'foo-bar-baz']);
     });
   });
 }


### PR DESCRIPTION
stop the auto conversion between snake-case and camelCase for DOM attributes.

See: https://github.com/angular/angular.dart/pull/560#discussion_r9718101
