### PR TITLE
Fixes #595 adding fragment identifier to install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Excellent read up on [contributing][contributing].
 [so]: http://stackoverflow.com/questions/tagged/angular.dart
 [list]: https://groups.google.com/forum/#!forum/angular-dart
 [tut]: https://angulardart.org/tutorial
-[pub]: http://pub.dartlang.org/packages/angular
+[pub]: http://pub.dartlang.org/packages/angular#installing
 [dart]: http://www.dartlang.org
 [ng]: http://angularjs.org/
 [issues]: https://github.com/angular/angular.dart/issues?state=open


### PR DESCRIPTION
Updated README to include a fragment identifier for the installation tab on the pub page.
