### PR TITLE
fix(DateFilter): should work on other locale

### DIFF
--- a/lib/angular.dart
+++ b/lib/angular.dart
@@ -14,6 +14,7 @@ import 'dart:html' as dom;
 import 'dart:js' as js;
 import 'package:di/di.dart';
 import 'package:di/dynamic_injector.dart';
+import 'package:intl/date_symbol_data_local.dart';
 
 /**
  * If you are writing code accessed from Angular expressions, you must include

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -89,8 +89,10 @@ Injector ngBootstrap({
   return zone.run(() {
     var rootElements = [element];
     Injector injector = injectorFactory(ngModules);
-    injector.get(Compiler)(rootElements, injector.get(DirectiveMap))
-        (injector, rootElements);
+    initializeDateFormatting(null, null).then((_) {
+      injector.get(Compiler)(rootElements, injector.get(DirectiveMap))
+          (injector, rootElements);
+    });
     return injector;
   });
 }

--- a/test/filter/date_spec.dart
+++ b/test/filter/date_spec.dart
@@ -1,6 +1,7 @@
 library date_spec;
 
 import '../_specs.dart';
+import 'package:intl/intl.dart';
 
 main() => describe('date', () {
   var morning   = DateTime.parse('2010-09-03T07:05:08.008Z'); //7am
@@ -62,5 +63,20 @@ main() => describe('date', () {
 
     date(noon, "shortTime");
     date(noon, "shortTime");
+  });
+
+  it('should accept various locales', () {
+
+    try {
+      Intl.defaultLocale = 'de';
+      expect(date(noon, "medium")).
+      toEqual('Sep 3, 2010 12:05:08 nachm.');
+
+      Intl.defaultLocale = 'fr';
+      expect(date(noon, "medium")).
+      toEqual('sept. 3, 2010 12:05:08 PM');
+    } finally {
+      Intl.defaultLocale = 'en';
+    }
   });
 });


### PR DESCRIPTION
Now date filter work only on 'en' locale and if we set
Intl.defaultLocale other locale than 'en' it causes LocaleDataException.

This patch fixes this bug.
