### PR TITLE
perf(scope): misc optims

### DIFF
--- a/lib/core/scope.dart
+++ b/lib/core/scope.dart
@@ -343,9 +343,8 @@ class Scope {
   }
 }
 
-_mapEqual(Map a, Map b) => a.length == b.length
-    ? a.keys.every((k) => b.containsKey(k) && a[k] == b[k])
-    : false;
+_mapEqual(Map a, Map b) => a.length == b.length &&
+    a.keys.every((k) => b.containsKey(k) && a[k] == b[k]);
 
 class RootScope extends Scope {
   static final STATE_APPLY = 'apply';


### PR DESCRIPTION
2 optimizations:
- children created from `createChild()` are always last in llist,
- `_mapEqual()` can stop comparing values on first mismatch

& some minor cleanup
