### PR TITLE
fix(parser): remove map-specific code from the parser

### DIFF
--- a/lib/core/parser/utils.dart
+++ b/lib/core/parser/utils.dart
@@ -74,8 +74,6 @@ Function ensureFunctionFromMap(Map map, String name) {
 getKeyed(object, key) {
   if (object is List) {
     return object[key.toInt()];
-  } else if (object is Map) {
-    return object["$key"]; // toString dangerous?
   } else if (object == null) {
     throw new EvalError('Accessing null object');
   } else {
@@ -89,8 +87,6 @@ setKeyed(object, key, value) {
     int index = key.toInt();
     if (object.length <= index) object.length = index + 1;
     object[index] = value;
-  } else if (object is Map) {
-    object["$key"] = value; // toString dangerous?
   } else {
     object[key] = value;
   }


### PR DESCRIPTION
The parser utility functions getKeyed() and setKeyed() treat instances
of the List and Map classes specially. For maps, the existing code
assumes that keys are always strings. If that is not the case, an
exception is likely thrown by the Map implementation. As map keys are
not necessarily strings, and there is code that handles generic
instances just fine, this commit simply removes the code that treats
maps specially.

Closes #608
