### PR TITLE
chore(parser): Simplify code by requiring Dart SDK 1.2+.

### DIFF
--- a/lib/core/parser/eval_access.dart
+++ b/lib/core/parser/eval_access.dart
@@ -148,50 +148,7 @@ abstract class AccessReflective {
   }
 
   static bool hasMethod(InstanceMirror mirror, Symbol symbol) {
-    return hasMethodHelper(mirror.type, symbol);
-  }
-
-  static final objectClassMirror = reflectClass(Object);
-  static final Set<Symbol> objectClassInstanceMethods =
-      new Set<Symbol>.from([#toString, #noSuchMethod]);
-
-  static final Function hasMethodHelper = (() {
-    try {
-      // Use ClassMirror.instanceMembers if available. It contains local
-      // as well as inherited members.
-      objectClassMirror.instanceMembers;
-      // For SDK 1.2 we have to use a somewhat complicated helper for this
-      // to work around bugs in the dart2js implementation.
-      return hasInstanceMethod;
-    } on NoSuchMethodError catch (e) {
-      // For SDK 1.0 we fall back to just using the local members.
-      return (type, symbol) => type.members[symbol] is MethodMirror;
-    } on UnimplementedError catch (e) {
-      // For SDK 1.1 we fall back to just using the local declarations.
-      return (type, symbol) => type.declarations[symbol] is MethodMirror;
-    }
-    return null;
-  })();
-
-  static bool hasInstanceMethod(type, symbol) {
-    // Always allow instance methods found in the Object class. This makes
-    // it easier to work around a few bugs in the dart2js implementation.
-    if (objectClassInstanceMethods.contains(symbol)) return true;
-    // Work around http://dartbug.com/16309 which causes access to the
-    // instance members of certain builtin types to throw exceptions
-    // while traversing the superclass chain.
-    var mirror;
-    try {
-      mirror = type.instanceMembers[symbol];
-    } on UnsupportedError catch (e) {
-      mirror = type.declarations[symbol];
-    }
-    // Work around http://dartbug.com/15760 which causes noSuchMethod
-    // forwarding stubs to be treated as members of all classes. We have
-    // already checked for the real instance methods in Object, so if the
-    // owner of this method is Object we simply filter it out.
-    if (mirror is !MethodMirror) return false;
-    return mirror.owner != objectClassMirror;
+    return mirror.type.instanceMembers[symbol] is MethodMirror;
   }
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -4,7 +4,7 @@ packages:
   analyzer:
     description: analyzer
     source: hosted
-    version: "0.10.5"
+    version: "0.11.10"
   args:
     description: args
     source: hosted
@@ -24,7 +24,7 @@ packages:
   di:
     description: di
     source: hosted
-    version: "0.0.32"
+    version: "0.0.33"
   html5lib:
     description: html5lib
     source: hosted
@@ -32,7 +32,7 @@ packages:
   intl:
     description: intl
     source: hosted
-    version: "0.9.1"
+    version: "0.9.6"
   logging:
     description: logging
     source: hosted
@@ -52,7 +52,7 @@ packages:
   shadow_dom:
     description: shadow_dom
     source: hosted
-    version: "0.9.1"
+    version: "0.9.2"
   source_maps:
     description: source_maps
     source: hosted
@@ -60,7 +60,7 @@ packages:
   stack_trace:
     description: stack_trace
     source: hosted
-    version: "0.9.1"
+    version: "0.9.2"
   unittest:
     description: unittest
     source: hosted

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,10 +8,7 @@ authors:
 description: Angular for dart.
 homepage: https://angulardart.org
 environment:
-  sdk: '>=0.8.10'
-dev_dependencies:
-  benchmark_harness: ">=1.0.0"
-  unittest: '>=0.8.7 <0.10.0'
+  sdk: '>=1.2.0'
 dependencies:
   analyzer: '>=0.10.0 <0.12.0'
   browser: '>=0.8.7 <0.10.0'
@@ -22,3 +19,6 @@ dependencies:
   perf_api: '>=0.0.8 <0.1.0'
   route_hierarchical: '>=0.4.7 <0.5.0'
   shadow_dom: '>=0.9.1 <1.0.0'
+dev_dependencies:
+  benchmark_harness: '>=1.0.0'
+  unittest: '>=0.8.7 <0.10.0'


### PR DESCRIPTION
The Dart SDK 1.2 (stable) and 1.3 (dev) both support the instanceMembers getter so we don't need the ugly workarounds any more.
