### PR TITLE
fix(doc-gen)

### DIFF
--- a/scripts/travis/publish-docs.sh
+++ b/scripts/travis/publish-docs.sh
@@ -9,7 +9,7 @@ echo Test result is: $TRAVIS_TEST_RESULT
 
 if [ "$CHANNEL" = "stable" ]; then
 
-    if [ $TRAVIS_TEST_RESULT -eq 0 ] && [ "$TRAVIS_BRANCH"="master" ]; then
+    if [ $TRAVIS_TEST_RESULT -eq 0 ] && [ "$TRAVIS_BRANCH" = "master" ]; then
             
             echo "Gettting current docs from docs.angulardart.org repo on Github"
             rm -Rf docs.angulardart.org


### PR DESCRIPTION
With no space between '=' this is treated as an assignment, which always evals to 1.  There needs to be spaces around the '=' so that Bash will treat this as a comparison.
