### PR TITLE
fix(NgModelValidators): ensure that number input types do are invalid when non-numeric characters

### DIFF
--- a/lib/directive/ng_model_validators.dart
+++ b/lib/directive/ng_model_validators.dart
@@ -90,6 +90,9 @@ class NgModelNumberValidator implements NgValidatable {
     if (value != null) {
       try {
         num val = double.parse(value.toString());
+        if (val.isNaN) {
+          return false;
+        }
       } catch(exception, stackTrace) {
         return false;
       }

--- a/test/directive/ng_model_spec.dart
+++ b/test/directive/ng_model_spec.dart
@@ -81,6 +81,18 @@ void main() {
         expect(inputElement.value).toEqual('');
       }));
 
+      it('should be invalid when the input value results in a NaN value', inject(() {
+        _.compile('<input type="number" ng-model="model" probe="p">');
+        Probe probe = _.rootScope.context['p'];
+        var ngModel = probe.directive(NgModel);
+        InputElement inputElement = probe.element;
+
+        inputElement.value = 'aa';
+        _.triggerEvent(inputElement, 'change');
+        expect(_.rootScope.context['model'].isNaN).toBe(true);
+        expect(ngModel.valid).toBe(false);
+      }));
+
       it('should write to input only if value is different', inject((Injector i, AstParser parser) {
         var scope = _.rootScope;
         var element = new dom.InputElement();


### PR DESCRIPTION
input[type="number"] treats non-numeric values as NaN values and these are considered valid when
double.parse is used. This commit fixes the validation for the model to properly address the
invalid number when a NaN value is detected.
