### PR TITLE
refactor(change_detection): remove unnecessary conditional expression

### DIFF
--- a/lib/change_detection/watch_group.dart
+++ b/lib/change_detection/watch_group.dart
@@ -264,7 +264,7 @@ class WatchGroup implements _EvalWatchList, _WatchGroupList {
 
     marker._previousEvalWatch = prev;
     marker._nextEvalWatch = next;
-    if (prev != null) prev._nextEvalWatch = marker;
+    prev._nextEvalWatch = marker;
     if (next != null) next._previousEvalWatch = marker;
 
     return childGroup;


### PR DESCRIPTION
`prev` is guaranteed to not be null here, the method would throw noSuchMethod if it were.

It's not a major performance hit or anything, but removing redundancy/unnecessary code feels good.
