### PR TITLE
fix(ngControl): unregister control from parent on detach

### DIFF
--- a/lib/directive/ng_control.dart
+++ b/lib/directive/ng_control.dart
@@ -1,6 +1,6 @@
 part of angular.directive;
 
-abstract class NgControl implements NgDetachAware {
+abstract class NgControl implements NgAttachAware, NgDetachAware {
   static const NG_VALID_CLASS          = "ng-valid";
   static const NG_INVALID_CLASS        = "ng-invalid";
   static const NG_PRISTINE_CLASS       = "ng-pristine";
@@ -38,10 +38,17 @@ abstract class NgControl implements NgDetachAware {
     _scope.on('submitNgControl').listen((e) => _onSubmit(e.data));
   }
 
+  @override
+  attach() {
+    _parentControl.addControl(this);
+  }
+
+  @override
   detach() {
     for (int i = _controls.length - 1; i >= 0; --i) {
       removeControl(_controls[i]);
     }
+    _parentControl.removeControl(this);
   }
 
   reset() {
@@ -70,7 +77,6 @@ abstract class NgControl implements NgDetachAware {
   get name => _name;
   set name(value) {
     _name = value;
-    _parentControl.addControl(this);
   }
 
   get element => _element;

--- a/test/directive/ng_form_spec.dart
+++ b/test/directive/ng_form_spec.dart
@@ -256,6 +256,23 @@ void main() {
         expect(form['two']).toBeNull();
         expect(form['three']).toBeNull();
       }));
+
+      it('should remove from parent when child is removed', inject((Scope scope, TestBed _) {
+        var element = $('<form name=myForm">' +
+                        '  <input type="text name="mega_name" ng-if="mega_visible" />' +
+                        '</form>');
+        _.compile(element);
+
+        scope.context['mega_visible'] = true;
+        scope.apply();
+
+        var form = scope.context['myForm'];
+        expect(form['mega_name']).toBeDefined();
+
+        scope.context['mega_visible'] = false;
+        scope.apply();
+        expect(form['mega_name']).toBeNull();
+      }));
     });
 
     describe('onSubmit', () {


### PR DESCRIPTION
Un-register a control with its parent on detach, and also move register call to attach().
Right now, when a form element(such as an input) is removed from the dom,
the parent control does not remove it from the list of controls.
