### PR TITLE
refactor(ng-a): simplify the code

### DIFF
--- a/lib/directive/ng_a.dart
+++ b/lib/directive/ng_a.dart
@@ -6,11 +6,11 @@ part of angular.directive;
  * @restrict E
  *
  * @description
- * Modifies the default behavior of the html A tag so that the default action is prevented when
- * the a href is empty or it contains `ng-click` directive.
+ * Modifies the default behavior of the html A tag so that the default action is
+ * prevented when the a href is empty or it contains `ng-click` directive.
  *
- * This change permits the easy creation of action links with the `ngClick` directive
- * without changing the location or causing page reloads, e.g.:
+ * This change permits the easy creation of action links with the `ngClick`
+ * directive without changing the location or causing page reloads, e.g.:
  * `<a href="" ng-click="model.$save()">Save</a>`
  */
 @NgDirective(selector: 'a[href]')
@@ -18,8 +18,7 @@ class NgADirective {
   final dom.Element element;
 
   NgADirective(this.element) {
-    if (element.attributes["href"] == "" ||
-        element.attributes.containsKey('ng-click')) {
+    if (element.attributes["href"] == "") {
       element.onClick.listen((event) {
         if (element.attributes["href"] == "") {
           event.preventDefault();


### PR DESCRIPTION
`element.attributes.containsKey('ng-click')` should not be needed here

Travis seems broken for now, tests do pass locally.
