### PR TITLE
chore: Fix docgen menu and make git fetch of docviewer work for repeat use

### DIFF
--- a/scripts/generate-documentation.sh
+++ b/scripts/generate-documentation.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 . $(dirname $0)/env.sh
 
+# Temporary change to delete the Build Status image markdown from the README (image md not supported by dartdoc-viewer)
+cp README.md README-orig.md
+cat README-orig.md | sed "1s/^AngularDart.*/AngularDart/" > README.md
 
 # Dart doc can not be run from the same directory as dartdoc-viewer
 # see: https://code.google.com/p/dart/issues/detail?id=17231
@@ -39,10 +42,18 @@ cd ..
 
 DOCVIEWER_DIR="dartdoc-viewer";
 if [ ! -d "$DOCVIEWER_DIR" ]; then
-  git clone https://github.com/angular/dartdoc-viewer.git -b angular-skin $DOCVIEWER_DIR
+   git clone https://github.com/angular/dartdoc-viewer.git -b angular-skin $DOCVIEWER_DIR
+else
+   (cd $DOCVIEWER_DIR; git pull origin angular-skin)
 fi;
 
+# Create a version file from the current build version
 head CHANGELOG.md | awk 'NR==2' | sed 's/^# //' > docs/VERSION
+
 rm -rf $DOCVIEWER_DIR/client/web/docs/
 mv docs/ $DOCVIEWER_DIR/client/web/docs/
 (cd $DOCVIEWER_DIR/client; pub build)
+
+# Revert the temp copy of the README.md file
+ mv README-orig.md README.md
+


### PR DESCRIPTION
Doc gen script cd to lib directory was breaking relative links for package includes. Also put the code back in to strip out images from the README.md (which aren't supported by docviewer) and added a line to do a git fetch when the docviewer directory exists but is possibly out of date.
