### PR TITLE
feat(travis): Only submit if all the builds complete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   global:
   - CHROME_BIN=/usr/bin/google-chrome
   - secure: "ZSUCLuDjvKEFmgjAd3GpUNCNkdjE66dEIiBfW+EfN0dv2+QHx/MHL4hRyKk2qbGjCr/suR9JWgmNE+Yu1A4fwzcYN52ehgyoLUCTL9YDk+XkFdFWpnjJ8364TDcDuJA0oxwcqJ9E3XUPv6sq1mbcX6DlkPKco7ZT8TLtGmd0nGA="
+
 before_install:
 - export DISPLAY=:99.0
 - ./scripts/travis/install.sh
@@ -21,7 +22,19 @@ before_script:
 - ./scripts/travis/setup.sh
 script:
 - ./scripts/travis/build.sh
-after_script:
-- ./scripts/travis/presubmit.sh
-- ./scripts/travis/publish-docs.sh
-
+after_success:
+- curl -o travis_after_all.py https://raw.github.com/jbdeboer/travis_after_all/master/travis_after_all.py
+- python travis_after_all.py
+- export $(cat .to_export_back)
+- |
+      if [ "$BUILD_LEADER" = "YES" ]; then
+        if [ "$BUILD_AGGREGATE_STATUS" = "others_succeeded" ]; then
+          echo "All Succeded! Submitting..."
+          ./scripts/travis/presubmit.sh
+          ./scripts/travis/publish-docs.sh
+        else
+          echo "Some Failed, not submitting"
+        fi
+      else
+        echo "Other builds have not finished, not submitting"
+      fi


### PR DESCRIPTION
Adds https://github.com/dmakhno/travis_after_all trick to AngularDart.

This solution works, but isn't terribly well-engineered.

(a) I didn't want to copy @dmarkhno's code into our repo, so we are referencing a fork under my name.
(b) A more elegant solution would be to rewrite this code in Node and publish it to npm.  Then we could just say:

```
after_success:
- if [ $(node node_modules/travis_all/all_success) ]; then ./scripts/publish; fi
```

For now, though, this works and makes the presubmit much more valuable.
