### PR TITLE
fixes for latest unittest lib >= 0.10.1

### DIFF
--- a/example/web/todo.dart
+++ b/example/web/todo.dart
@@ -1,10 +1,10 @@
 library todo;
 
+import 'dart:html';
+
 import 'package:angular/angular.dart';
 import 'package:angular/angular_dynamic.dart';
 import 'package:angular/playback/playback_http.dart';
-
-import 'dart:html';
 
 class Item {
   String text;

--- a/lib/mock/module.dart
+++ b/lib/mock/module.dart
@@ -4,9 +4,10 @@ import 'dart:async' as dart_async;
 import 'dart:collection' show ListBase;
 import 'dart:html';
 import 'dart:js' as js;
+
 import 'package:angular/angular.dart';
 import 'package:di/di.dart';
-import 'package:unittest/mock.dart';
+import 'package:mock/mock.dart';
 
 import 'http_backend.dart';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -24,7 +24,7 @@ packages:
   code_transformers:
     description: code_transformers
     source: hosted
-    version: "0.1.0"
+    version: "0.1.0+1"
   collection:
     description: collection
     source: hosted
@@ -48,10 +48,18 @@ packages:
     description: logging
     source: hosted
     version: "0.9.1+1"
+  matcher:
+    description: matcher
+    source: hosted
+    version: "0.10.0"
   meta:
     description: meta
     source: hosted
     version: "0.8.8"
+  mock:
+    description: mock
+    source: hosted
+    version: "0.10.0"
   path:
     description: path
     source: hosted
@@ -79,7 +87,7 @@ packages:
   unittest:
     description: unittest
     source: hosted
-    version: "0.9.3"
+    version: "0.10.1+1"
   utf:
     description: utf
     source: hosted

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,4 +27,5 @@ dependencies:
   shadow_dom: '>=0.9.1 <1.0.0'
 dev_dependencies:
   benchmark_harness: '>=1.0.0'
-  unittest: '>=0.8.7 <0.10.0'
+  unittest: '>=0.10.1 <0.12.0'
+  mock: '>=0.10.0 <0.12.0'

--- a/test/_specs.dart
+++ b/test/_specs.dart
@@ -1,17 +1,17 @@
 library ng_specs;
 
 import 'dart:html' hide Animation;
-import 'package:unittest/unittest.dart' as unit;
+
 import 'package:angular/angular.dart';
 import 'package:angular/mock/module.dart';
 import 'package:angular/mock/test_injection.dart';
-import 'package:collection/wrappers.dart' show DelegatingList;
+import 'package:unittest/unittest.dart' as unit;
 
 import 'jasmine_syntax.dart' as jasmine_syntax;
 
 export 'dart:html' hide Animation;
 export 'package:unittest/unittest.dart';
-export 'package:unittest/mock.dart';
+export 'package:mock/mock.dart';
 export 'package:di/dynamic_injector.dart';
 export 'package:angular/angular.dart';
 export 'package:angular/animate/module.dart';


### PR DESCRIPTION
There are big-ish breaking changes coming to unittest.

angular is safe, except for using mock directly from unittest - `mock` has been moved to its own package.
