### PR TITLE
chore(karma): Use Dartium launcher.

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -78,10 +78,10 @@ illustrative purposes.)
 # CHROME_BIN: path to a Chrome browser executable; e.g.,
 export CHROME_BIN="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 
-# CHROME_CANARY_BIN: path to a Dartium browser executable; e.g.,
-export CHROME_CANARY_BIN="$DART_EDITOR_DIR/chromium/Chromium.app/Contents/MacOS/Chromium"
+# DARTIUM_BIN: path to a Dartium browser executable; e.g.,
+export DARTIUM_BIN="$DART_EDITOR_DIR/chromium/Chromium.app/Contents/MacOS/Chromium"
 ```
-**Note**: the `$CHROME_CANARY_BIN` environment variable is used by karma to run
+**Note**: the `$DARTIUM_BIN` environment variable is used by karma to run
 your tests in dartium instead of chromium. If you don't do this, the dart2js
 compile will make the tests run extremely slow since it has to wait for a full
 js compile each time.
@@ -183,7 +183,7 @@ Set the parameters as follow:
 - **JavaScript file**: `node_modules/karma/bin/karma`
 - **Application parameters**: `start karma.conf --reporters dots --port 8765 --browsers=Dartium`
 - **Environment variables**:
-    - **CHROME_CANARY_BIN**: `/path/to/dartium`
+    - **DARTIUM_BIN**: `/path/to/dartium`
     - **PATH**: `/path/to/dart-sdk/bin`
     - **DART_FLAGS**: `--enable_type_checks --enable_asserts`
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -39,11 +39,8 @@ module.exports = function(config) {
     ],
 
     customLaunchers: {
-      Dartium: { base: 'ChromeCanary', flags: ['--no-sandbox'] },
       ChromeNoSandbox: { base: 'Chrome', flags: ['--no-sandbox'] }
     },
-
-    browsers: ['Dartium'],
 
     preprocessors: {
       'test/core/parser/generated_getter_setter.dart': ['parser-getter-setter']

--- a/karma_run.sh
+++ b/karma_run.sh
@@ -3,7 +3,7 @@
 # OS-specific Dartium path defaults
 case $( uname -s ) in
   Darwin)
-    CHROME_CANARY_BIN=${CHROME_CANARY_BIN:-"/Applications/dart/chromium/Chromium.app/Contents/MacOS/Chromium"};;
+    DARTIUM_BIN=${DARTIUM_BIN:-"/Applications/dart/chromium/Chromium.app/Contents/MacOS/Chromium"};;
 esac
 
 # Check for node

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "karma" : "~0.12.0",
     "karma-dart" : "~0.2.6",
     "karma-script-launcher": "*",
-    "karma-chrome-launcher": "*",
+    "karma-chrome-launcher": "~0.1.3",
     "karma-firefox-launcher": "*",
     "karma-junit-reporter": "~0.2.1",
     "jasmine-node": "*",

--- a/run-test.sh
+++ b/run-test.sh
@@ -7,15 +7,14 @@ export DART_SDK=`which dart | sed -e 's/\/dart\-sdk\/.*$/\/dart-sdk/'`
 # OS-specific Dartium path defaults
 case $( uname -s ) in
   Darwin)
-    CHROME_CANARY_BIN=${CHROME_CANARY_BIN:-"/Applications/dart/chromium/Chromium.app/Contents/MacOS/Chromium"};;
+    DARTIUM_BIN=${DARTIUM_BIN:-"/Applications/dart/chromium/Chromium.app/Contents/MacOS/Chromium"};;
 esac
-if [ ! -x "$CHROME_CANARY_BIN" ]; then
+if [ ! -x "$DARTIUM_BIN" ]; then
   echo "Unable to determine path to Dartium browser. To correct:"
-  echo "export CHROME_CANARY_BIN=path/to/dartium"
+  echo "export DARTIUM_BIN=path/to/dartium"
   exit 1;
 fi
-export CHROME_CANARY_BIN
-export DART_FLAGS="--enable-type-checks --enable-asserts"
+export DARTIUM_BIN
 
 # Check for node
 if [ -z "$(which node)" ]; then
@@ -44,5 +43,5 @@ scripts/test-expression-extractor.sh
   node_modules/jasmine-node/bin/jasmine-node playback_middleware/spec/ &&
   node "node_modules/karma/bin/karma" start karma.conf \
     --reporters=junit,dots --port=8765 --runner-port=8766 \
-    --browsers=ChromeCanary,Chrome --single-run --no-colors
+    --browsers=Dartium,Chrome --single-run --no-colors
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -31,7 +31,6 @@ export DARTANALYZER=${DARTANALYZER:-"$DARTSDK/bin/dartanalyzer"}
 export DARTDOC=${DARTDOC:-"$DARTSDK/bin/dartdoc"}
 export DART_DOCGEN=${DART_DOCGEN:-"$DARTSDK/bin/docgen"}
 
-export CHROME_CANARY_BIN=${CHROME_CANARY_BIN:-"$DARTIUM"}
+export DARTIUM_BIN=${DARTIUM_BIN:-"$DARTIUM"}
 export CHROME_BIN=${CHROME_BIN:-"google-chrome"}
-export DART_FLAGS='--enable_type_checks --enable_asserts'
 export PATH=$PATH:$DARTSDK/bin


### PR DESCRIPTION
There is a Dartium launcher (in karma-chrome-lauchdr) which can be used to launch Dartium browser in checked mode. There' no need for using ChromeCanary to launch Dartium any more.
