### PR TITLE
chore(run-test.sh): use package.json

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -24,8 +24,7 @@ if [ -z "$(which node)" ]; then
 fi
 
 # Run npm install so we are up-to-date
-npm install karma karma-dart karma-chrome-launcher \
-  karma-script-launcher karma-junit-reporter jasmine-node;
+npm install
 
 # Print the dart VM version to the logs
 dart --version


### PR DESCRIPTION
Remove incomplete package list as arguments to `npm install`. This argument list is unnecessary since we have a `package.json` file.
