### PR TITLE
Adding utility to wrap 'pub build' and generate errors if any new warnings occur

### DIFF
--- a/bin/pub_build.dart
+++ b/bin/pub_build.dart
@@ -1,0 +1,109 @@
+
+import 'dart:io';
+import 'dart:convert';
+import 'package:args/args.dart';
+import 'package:path/path.dart' as path;
+
+/// Utility to run 'pub build' and fail if any unexpected warnings occur.
+main(args) {
+  var cmds = Commands.parse(args);
+
+  var initialDir = Directory.current;
+  Directory.current = cmds.packageHome;
+
+  var result = Process.runSync('pub', ['build', '--format=json']);
+  if (result.exitCode != 0) {
+    print('pub build failed:');
+    print(result.stdout);
+    print(result.stderr);
+    exit(result.exitCode);
+  }
+
+  Directory.current = initialDir;
+
+  var actual = JSON.decode(result.stdout);
+  var entries = actual['log']
+      .where((entry) => entry['level'] != 'Fine' && entry['level'] != 'Info')
+      .map((entry) =>
+          '${entry['assetId']['path']} from ${entry['transformer']['name']} :'
+          '${entry['level']}: ${entry['message']}')
+      .toList();
+
+  entries.sort();
+
+  if (cmds.reset) {
+    var lines = entries.map((msg) => '  ${JSON.encode(msg)}');
+    cmds.expectations.writeAsStringSync('[\n${lines.join(',\n')}\n]');
+    return;
+  }
+
+  var expected = JSON.decode(cmds.expectations.readAsStringSync());
+  var unexpected = entries.toSet()
+    ..removeAll(expected);
+
+  if (unexpected.isNotEmpty) {
+    print('Encountered unexpected pub build messages:');
+    print(unexpected.join('\n'));
+    print(' ');
+    print('This can be corrected by running:');
+    print('  dart ${path.relative(Platform.script.path)} ${args.join(' ')} '
+        '--reset');
+    exit(-1);
+  }
+}
+
+class Commands {
+  Directory packageHome;
+  File expectations;
+  bool reset;
+
+  static Commands parse(List<String> args) {
+    var parser = new ArgParser()
+    ..addOption('package_home', abbr: 'p',
+        help: 'The root directory of the package to be built.',
+        defaultsTo: '.')
+    ..addOption('expectations', abbr: 'e',
+        help: 'A JSON file containing the expected warning and error messages.')
+    ..addFlag('reset', negatable: false,
+        help: 'Regenerate the expectations with the results of the build.')
+    ..addFlag('help', abbr: 'h',
+        negatable: false, help: 'Displays this help and exit.');
+
+    showUsage() {
+      print('Usage: dart pub_build.dart [options]');
+      print('\nThese are valid options expected by pub_build.dart:');
+      print(parser.getUsage());
+    }
+
+    var cmds = new Commands();
+    var res;
+    try {
+      res = parser.parse(args);
+    } on FormatException catch (e) {
+      print(e.message);
+      showUsage();
+      exit(1);
+    }
+
+    if (res['help']) {
+      showUsage();
+      exit(0);
+    }
+
+    cmds.packageHome = new Directory(res['package_home']);
+    if (!cmds.packageHome.existsSync()) {
+      print('Unable to find directory ${res['package_home']}');
+      exit(-1);
+    }
+
+    cmds.expectations = new File(path.absolute(res['expectations']));
+    if (!cmds.expectations.existsSync()) {
+      print('Unable to open expectations file ${res['expectations']}');
+      exit(-1);
+    }
+
+    cmds.reset = res['reset'];
+
+    return cmds;
+  }
+}

--- a/example/expected_warnings.json
+++ b/example/expected_warnings.json
@@ -1,0 +1,10 @@
+[
+  "web/animation.dart from Dart2JS :Warning: 1 warning(s) and 2 hint(s) suppressed in package:angular.",
+  "web/animation.dart from Dart2JS :Warning: 11 warning(s) and 1 hint(s) suppressed in package:route_hierarchical.",
+  "web/bouncing_balls.dart from Dart2JS :Warning: 1 warning(s) and 2 hint(s) suppressed in package:angular.",
+  "web/bouncing_balls.dart from Dart2JS :Warning: 11 warning(s) and 1 hint(s) suppressed in package:route_hierarchical.",
+  "web/hello_world.dart from Dart2JS :Warning: 1 warning(s) and 2 hint(s) suppressed in package:angular.",
+  "web/hello_world.dart from Dart2JS :Warning: 11 warning(s) and 1 hint(s) suppressed in package:route_hierarchical.",
+  "web/todo.dart from Dart2JS :Warning: 1 warning(s) and 2 hint(s) suppressed in package:angular.",
+  "web/todo.dart from Dart2JS :Warning: 11 warning(s) and 1 hint(s) suppressed in package:route_hierarchical."
+]

--- a/run-test.sh
+++ b/run-test.sh
@@ -45,3 +45,4 @@ scripts/test-expression-extractor.sh
     --reporters=junit,dots --port=8765 --runner-port=8766 \
     --browsers=Dartium,Chrome --single-run --no-colors
 
+dart "bin/pub_build.dart" -p example -e "example/expected_warnings.json"


### PR DESCRIPTION
This is to catch cases where warnings are introduced into the examples but the build does not fail.

I've also opened dartbug.com/17978 to request that this functionality be included in `pub build`.
