### PR TITLE
refactor(InputCheckboxDirective): fix API doc and refactor ng-true/false-value

### DIFF
--- a/lib/directive/module.dart
+++ b/lib/directive/module.dart
@@ -5,7 +5,6 @@
 * This package is imported for you as part of [angular.dart](#angular/angular),
 * and lists all of the basic directives that are part of Angular.
 *
-*
 */
 library angular.directive;
 
@@ -69,8 +68,8 @@ class NgDirectiveModule extends Module {
     value(ContentEditableDirective, null);
     value(NgModel, null);
     value(NgValue, new NgValue(null));
-    value(NgTrueValue, new NgTrueValue(null));
-    value(NgFalseValue, new NgFalseValue(null));
+    value(NgTrueValue, new NgTrueValue());
+    value(NgFalseValue, new NgFalseValue());
     value(NgSwitchDirective, null);
     value(NgSwitchWhenDirective, null);
     value(NgSwitchDefaultDirective, null);

--- a/test/directive/ng_model_spec.dart
+++ b/test/directive/ng_model_spec.dart
@@ -631,7 +631,6 @@ void main() {
         expect(model.dirty).toEqual(true);
       });
 
-
       it('should update input value from model using ng-true-value/false', (Scope scope) {
         var element = _.compile('<input type="checkbox" ng-model="model" ng-true-value="1" ng-false-value="0">');
 
@@ -654,7 +653,6 @@ void main() {
         expect(scope.context['model']).toBe(0);
       });
 
-
       it('should allow non boolean values like null, 0, 1', (Scope scope) {
         var element = _.compile('<input type="checkbox" ng-model="model">');
 
@@ -674,7 +672,6 @@ void main() {
         expect(element.checked).toBe(false);
       });
 
-
       it('should update model from the input value', (Scope scope) {
         var element = _.compile('<input type="checkbox" ng-model="model">');
 
@@ -685,6 +682,23 @@ void main() {
         element.checked = false;
         _.triggerEvent(element, 'change');
         expect(scope.context['model']).toBe(false);
+      });
+
+      it('should update model from the input using ng-true-value/false', (Scope scope) {
+        var element = _.compile('<input type="checkbox" ng-model="model" '
+                                'ng-true-value="yes" ng-false-value="no">');
+        scope.apply(() {
+          scope.context['yes'] = 'yes sir!';
+          scope.context['no'] = 'no, sorry';
+        });
+
+        element.checked = true;
+        _.triggerEvent(element, 'change');
+        expect(scope.context['model']).toEqual('yes sir!');
+
+        element.checked = false;
+        _.triggerEvent(element, 'change');
+        expect(scope.context['model']).toEqual('no, sorry');
       });
 
       it('should only render the input value upon the next digest', (Scope scope) {


### PR DESCRIPTION
- Refactor `NgTrueValue` and `NgFalseValue` so that it smells good!
- Refactor/clean-up InputCheckboxDirective.
- Update `input[type=checkbox]` API doc to reflect AngularDart behavior while following AngularJS-like style.
