### PR TITLE
refactor(NgValue): use the @NgDirective module feature

### DIFF
--- a/lib/directive/input_select.dart
+++ b/lib/directive/input_select.dart
@@ -90,7 +90,7 @@ class InputSelect implements NgAttachAware {
  * provides [ng-value] which allows binding to any expression.
  *
  */
-@NgDirective(selector: 'option')
+@NgDirective(selector: 'option', module: NgValue.moduleFactory)
 class OptionValue implements NgAttachAware,
     NgDetachAware {
   final InputSelect _inputSelectDirective;
@@ -117,7 +117,7 @@ class OptionValue implements NgAttachAware,
     }
   }
 
-  get ngValue => _ngValue.readValue(_element);
+  get ngValue => _ngValue.value;
 }
 
 class _SelectMode {

--- a/lib/directive/module.dart
+++ b/lib/directive/module.dart
@@ -69,7 +69,7 @@ class NgDirectiveModule extends Module {
     value(OptionValue, null);
     value(ContentEditable, null);
     value(NgModel, null);
-    value(NgValue, new NgValue(null));
+    value(NgValue, null);
     value(NgTrueValue, new NgTrueValue());
     value(NgFalseValue, new NgFalseValue());
     value(NgSwitch, null);


### PR DESCRIPTION
- Use the `@NgDirective` `module` feature to inject an `NgValue` instance into `OptionValueDirective` and `InputRadioDirective` when no `ng-value` attribute is present. This results in a much cleaner design since the `NgValue` `element` is still bound to its "containing" DOM element rather than being null.
- Update `ng-value` API documentation.
