### PR TITLE
feat(Scope): Allow turning emission of scope stats from console.

### DIFF
--- a/lib/introspection_js.dart
+++ b/lib/introspection_js.dart
@@ -16,10 +16,13 @@ import 'package:angular/core_dom/module_internal.dart';
 var elementExpando = new Expando('element');
 
 publishToJavaScript() {
+  emitScopeStats(emit) => (_, dom.Node node) => ngInjector(node).get(ScopeStatsConfig).emit = emit;
   js.context
     ..['ngProbe'] = new js.JsFunction.withThis((_, dom.Node node) => _jsProbe(ngProbe(node)))
     ..['ngInjector'] = new js.JsFunction.withThis((_, dom.Node node) => _jsInjector(ngInjector(node)))
     ..['ngScope'] = new js.JsFunction.withThis((_, dom.Node node) => _jsScope(ngScope(node)))
+    ..['enableScopeStats'] = new js.JsFunction.withThis(emitScopeStats(true))
+    ..['disableScopeStats'] = new js.JsFunction.withThis(emitScopeStats(false))
     ..['ngQuery'] = new js.JsFunction.withThis((_, dom.Node node, String selector, [String containsText]) =>
   new js.JsArray.from(ngQuery(node, selector, containsText)));
 }


### PR DESCRIPTION
To enable emission of ScopeStats from console one can call function `enableScopeStats(Node)`. To disable call function `disableScopeStats(node)`.

Fixes #836
