### PR TITLE
Fixing expression extractor & test

### DIFF
--- a/lib/tools/source_crawler_impl.dart
+++ b/lib/tools/source_crawler_impl.dart
@@ -45,7 +45,9 @@ class SourceCrawlerImpl implements SourceCrawler {
                       String currentFile, List<String> visited,
                       List<String> toVisit) {
     cu.directives.forEach((Directive directive) {
-      if (directive is ImportDirective || directive is PartDirective) {
+      if (directive is ImportDirective ||
+          directive is PartDirective ||
+          directive is ExportDirective) {
         UriBasedDirective import = directive;
         String canonicalFile = canonicalizeImportPath(
             currentDir, currentFile, import.uri.stringValue);

--- a/scripts/test-expression-extractor.sh
+++ b/scripts/test-expression-extractor.sh
@@ -8,7 +8,7 @@ rm -rf xxx.dart
 
 OUT=$(mktemp XXX.dart)
 
-dart bin/expression_extractor.dart example/web/todo.dart example /dev/null /dev/null $OUT
+dart --package-root=example/packages bin/expression_extractor.dart example/web/todo.dart example /dev/null /dev/null $OUT
 
 if [[ -e $OUT ]]; then
   echo "Expression extractor created an output file"

--- a/test/io/source_metadata_extractor_spec.dart
+++ b/test/io/source_metadata_extractor_spec.dart
@@ -15,7 +15,7 @@ void main() {
       sourceMetadataExtractor
       .gatherDirectiveInfo('test/io/test_files/main.dart', sourceCrawler);
 
-      expect(directives, hasLength(2));
+      expect(directives, hasLength(4));
 
       DirectiveInfo info = directives.elementAt(1);
       expect(info.expressionAttrs, unorderedEquals(['expr', 'another-expression',


### PR DESCRIPTION
Noticed during investigation of https://github.com/angular/angular.dart/pull/747 that this test was not failing when it should have been, there were two issues-
- The packages were not being specified for the test, so the expression extractor was skipping all Angular code.
- The source crawler was not including exported libraries which causes it to incorrectly skip chunks of Angular code.

End result is that the expression list being extracted was a fraction of what it should have been.
