### PR TITLE
fix(filters): handle the current locale correctly

### DIFF
--- a/lib/filter/currency.dart
+++ b/lib/filter/currency.dart
@@ -12,12 +12,8 @@ part of angular.filter;
  */
 @NgFilter(name:'currency')
 class Currency implements Function {
-  NumberFormat nf = new NumberFormat();
 
-  Currency() {
-    nf.minimumFractionDigits = 2;
-    nf.maximumFractionDigits = 2;
-  }
+  var _nfs = new Map<String, NumberFormat>();
 
   /**
    *  [value]: the value to format
@@ -30,6 +26,14 @@ class Currency implements Function {
     if (value is String) value = double.parse(value);
     if (value is! num) return value;
     if (value.isNaN) return '';
+    var verifiedLocale = Intl.verifiedLocale(Intl.getCurrentLocale(), NumberFormat.localeExists);
+    var nf = _nfs[verifiedLocale];
+    if (nf == null) {
+      nf = new NumberFormat();
+      nf.minimumFractionDigits = 2;
+      nf.maximumFractionDigits = 2;
+      _nfs[verifiedLocale] = nf;
+    }
     var neg = value < 0;
     if (neg) value = -value;
     var before = neg ? '(' : '';

--- a/lib/filter/number.dart
+++ b/lib/filter/number.dart
@@ -14,7 +14,7 @@ part of angular.filter;
 @NgFilter(name:'number')
 class Number {
 
-  Map<num, NumberFormat> nfs = new Map<num, NumberFormat>();
+  var _nfs = new Map<String, Map<num, NumberFormat>>();
 
   /**
    *  [value]: the value to format
@@ -28,14 +28,16 @@ class Number {
     if (value is String) value = double.parse(value);
     if (!(value is num)) return value;
     if (value.isNaN) return '';
-    var nf = nfs[fractionSize];
+    var verifiedLocale = Intl.verifiedLocale(Intl.getCurrentLocale(), NumberFormat.localeExists);
+    _nfs.putIfAbsent(verifiedLocale, () => new Map<num, NumberFormat>());
+    var nf = _nfs[verifiedLocale][fractionSize];
     if (nf == null) {
       nf = new NumberFormat()..maximumIntegerDigits = 9;
       if (fractionSize != null) {
         nf.minimumFractionDigits = fractionSize;
         nf.maximumFractionDigits = fractionSize;
       }
-      nfs[fractionSize] = nf;
+      _nfs[verifiedLocale][fractionSize] = nf;
     }
     return nf.format(value);
   }

--- a/test/filter/currency_spec.dart
+++ b/test/filter/currency_spec.dart
@@ -1,6 +1,7 @@
 library curerncy_spec;
 
 import '../_specs.dart';
+import 'package:intl/intl.dart';
 
 void main() {
   describe('number', () {
@@ -27,6 +28,10 @@ void main() {
       expect(currency(1.07 + 1 - 2.07)).toEqual(r'$0.00');
       expect(currency(0.008)).toEqual(r'$0.01');
       expect(currency(0.003)).toEqual(r'$0.00');
+    });
+
+    it('should accept various locales', () {
+      expect(Intl.withLocale('de', () => currency(0.008, '€', false))).toEqual(r'0,01€');
     });
   });
 }

--- a/test/filter/date_spec.dart
+++ b/test/filter/date_spec.dart
@@ -1,7 +1,6 @@
 library date_spec;
 
 import '../_specs.dart';
-import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
 
 void main() {
@@ -69,20 +68,10 @@ void main() {
 
 
     it('should accept various locales', async(() {
-      initializeDateFormatting(null, null).then((_) {
-        String defaultLocale = Intl.defaultLocale;
-        try {
-          Intl.defaultLocale = 'de';
-          expect(date(noon, "medium")).
-          toEqual('Sep 3, 2010 12:05:08 nachm.');
-
-          Intl.defaultLocale = 'fr';
-          expect(date(noon, "medium")).
-          toEqual('sept. 3, 2010 12:05:08 PM');
-        } finally {
-          Intl.defaultLocale = defaultLocale;
-        }
-      });
+      expect(Intl.withLocale('de', () => date(noon, "medium"))).
+        toEqual('Sep 3, 2010 12:05:08 nachm.');
+      expect(Intl.withLocale('fr', () => date(noon, "medium"))).
+        toEqual('sept. 3, 2010 12:05:08 PM');
     }));
   });
 }

--- a/test/filter/number_spec.dart
+++ b/test/filter/number_spec.dart
@@ -1,6 +1,7 @@
 library number_spec;
 
 import '../_specs.dart';
+import 'package:intl/intl.dart';
 
 void main() {
   describe('number', () {
@@ -44,6 +45,10 @@ void main() {
       expect(number(-1e-50, 0)).toEqual('-0');
       expect(number(-1e-6, 6)).toEqual('-0.000001');
       expect(number(-1e-7, 6)).toEqual('-0.000000');
+    });
+
+    it('should accept various locales', () {
+      expect(Intl.withLocale('de', () => number(1234.567, 2))).toEqual('1.234,57');
     });
   });
 }


### PR DESCRIPTION
The NumberFormat uses the locale which is set when the formatter is
initialized. This means a NumberFormat should be cached for each locale.
