### PR TITLE
chore(dart2js): Re-enable tests that were disabled

### DIFF
--- a/test/routing/ng_view_spec.dart
+++ b/test/routing/ng_view_spec.dart
@@ -101,33 +101,28 @@ main() {
          '<h2>Read Book 1234</h2>'));
     });
 
-    // This test is disable on dart2js because it is flaky
-    // on dart v1.2. Kasper is looking into it. In the
-    // meantime we are disabling it.
-    if (!identical(1, 1.0)) {
-      it('should switch nested templates', async(() {
-        Element root = _.compile('<ng-view></ng-view>');
-        expect(root.text).toEqual('');
+    it('should switch nested templates', async(() {
+      Element root = _.compile('<ng-view></ng-view>');
+      expect(root.text).toEqual('');
 
-        router.route('/library/all');
-        microLeap();
-        expect(root.text).toEqual('LibraryBooks');
+      router.route('/library/all');
+      microLeap();
+      expect(root.text).toEqual('LibraryBooks');
 
-        router.route('/library/1234');
-        microLeap();
-        expect(root.text).toEqual('LibraryBook 1234');
+      router.route('/library/1234');
+      microLeap();
+      expect(root.text).toEqual('LibraryBook 1234');
 
-        // nothing should change here
-        router.route('/library/1234/overview');
-        microLeap();
-        expect(root.text).toEqual('LibraryBook 1234');
+      // nothing should change here
+      router.route('/library/1234/overview');
+      microLeap();
+      expect(root.text).toEqual('LibraryBook 1234');
 
-        // nothing should change here
-        router.route('/library/1234/read');
-        microLeap();
-        expect(root.text).toEqual('LibraryRead Book 1234');
-      }));
-    }
+      // nothing should change here
+      router.route('/library/1234/read');
+      microLeap();
+      expect(root.text).toEqual('LibraryRead Book 1234');
+    }));
   });
 }
 

--- a/test/routing/routing_spec.dart
+++ b/test/routing/routing_spec.dart
@@ -6,8 +6,6 @@ import 'package:angular/angular_dynamic.dart';
 import 'dart:async';
 
 main() {
-  // Do not run in dart2js until the exception is fixed
-  if (identical(1.0, 1)) return;
   describe('routing', () {
     TestBed _;
     Router router;


### PR DESCRIPTION
The tests used to be disabled because of a V8 bug in Chrome 33.
