### PR TITLE
Expression extractor transformer URI improvements

### DIFF
--- a/lib/tools/transformer/referenced_uris.dart
+++ b/lib/tools/transformer/referenced_uris.dart
@@ -190,11 +190,10 @@ class _Processor {
 
   Future<_CacheEntry> cacheEntry(_CacheEntry entry) {
     return transform.readInputAsString(entry.assetId).then((contents) {
-      if (contents == null) {
-        warn('Unable to find ${entry.uri} at ${entry.assetId}', entry.element);
-      }
       entry.contents = contents;
       return entry;
+    }, onError: (e) {
+      warn('Unable to find ${entry.uri} at ${entry.assetId}', entry.element);
     });
   }
 
@@ -221,6 +220,10 @@ class _Processor {
     templateUriRewrites.forEach((regexp, replacement) {
       uri = uri.replaceFirst(regexp, replacement);
     });
+    // Normalize packages/ uri's to be /packages/
+    if (uri.startsWith('packages/')) {
+      uri = '/' + uri;
+    }
     return uri;
   }
 


### PR DESCRIPTION
- Adding support for resolving 'packages/' uris (previously only handled '/packages/') from annotation templateUris.
- Adding support for /packages/ uris to the html_files transformer parameter for referencing package-relative URIs.
- Generating warnings for not-found files rather than build errors.

This is to address https://github.com/angular/angular.dart/issues/874
