### PR TITLE
Fix for crashes in metadata extraction while in pub serve

### DIFF
--- a/lib/tools/source_metadata_extractor.dart
+++ b/lib/tools/source_metadata_extractor.dart
@@ -182,7 +182,8 @@ class DirectiveMetadataCollectingVisitor {
                 StringLiteral attNameLiteral = ann.arguments.arguments.first;
                 if (meta.attributeMappings
                         .containsKey(attNameLiteral.stringValue)) {
-                  throw 'Attribute mapping already defined for $fieldName';
+                  throw 'Attribute mapping already defined for '
+                      '${clazz.name}.$fieldName';
                 }
                 meta.attributeMappings[attNameLiteral.stringValue] =
                     _attrAnnotationsToSpec[ann.name.name] + fieldName;

--- a/lib/tools/transformer/metadata_extractor.dart
+++ b/lib/tools/transformer/metadata_extractor.dart
@@ -2,6 +2,7 @@ library angular.metadata_extractor;
 
 import 'package:analyzer/src/generated/ast.dart';
 import 'package:analyzer/src/generated/element.dart';
+import 'package:analyzer/src/generated/parser.dart' show ResolutionCopier;
 import 'package:analyzer/src/generated/scanner.dart';
 import 'package:analyzer/src/generated/utilities_dart.dart' show ParameterKind;
 import 'package:barback/barback.dart';
@@ -336,7 +337,14 @@ class AnnotationExtractor {
 
     // Default to using the first acceptable annotation- not sure if
     // more than one should ever occur.
-    var annotation = acceptableAnnotations.first;
+    var sourceAnnotation = acceptableAnnotations.first;
+
+    // Clone the annotation so we don't modify the one in the persistent AST.
+    var index = type.annotations.indexOf(sourceAnnotation);
+    var annotation = new AstCloner().visitAnnotation(sourceAnnotation);
+    ResolutionCopier.copyResolutionData(sourceAnnotation, annotation);
+    type.annotations[index] = annotation;
+
     var mapArg = annotation.arguments.arguments.firstWhere((arg) =>
         (arg is NamedExpression) && (arg.name.label.name == 'map'),
         orElse: () => null);

--- a/test/tools/transformer/expression_generator_spec.dart
+++ b/test/tools/transformer/expression_generator_spec.dart
@@ -143,7 +143,7 @@ import 'package:angular/change_detection/change_detection.dart';
 ''';
 
 const String libAngular = '''
-library angular.core.annotation;
+library angular.core.annotation_src;
 
 class NgComponent {
   const NgComponent({String templateUrl, String selector});

--- a/test/tools/transformer/metadata_generator_spec.dart
+++ b/test/tools/transformer/metadata_generator_spec.dart
@@ -508,6 +508,51 @@ main() {
           imports: [],
           classes: {});
     });
+
+    it('does not modify annotations in-place', () {
+      var main = '''
+          import 'package:angular/angular.dart';
+          import 'second.dart';
+
+          @NgDirective(map: {})
+          class Engine {
+            @NgTwoWay('two-way-stuff')
+            String get twoWayStuff => null;
+          }
+          main() {}
+          ''';
+      return generates(phases,
+          inputs: {
+            'angular|lib/angular.dart': libAngular,
+            'a|web/main.dart': main,
+            'a|web/second.dart': '''library second;'''
+          },
+          imports: [
+            'import \'main.dart\' as import_0;',
+            'import \'package:angular/angular.dart\' as import_1;',
+          ],
+          classes: {
+            'import_0.Engine': [
+              'const import_1.NgDirective(map: const {'
+                '\'two-way-stuff\': \'<=>twoWayStuff\'})',
+            ]
+          }).then((_) => generates(phases,
+              inputs: {
+                'angular|lib/angular.dart': libAngular,
+                'a|web/main.dart': main,
+                'a|web/second.dart': '''library a.second;'''
+              },
+              imports: [
+                'import \'main.dart\' as import_0;',
+                'import \'package:angular/angular.dart\' as import_1;',
+              ],
+              classes: {
+                'import_0.Engine': [
+                  'const import_1.NgDirective(map: const {'
+                    '\'two-way-stuff\': \'<=>twoWayStuff\'})',
+                ]
+              }));
+    });
   });
 }
 
@@ -568,7 +613,7 @@ const String footer = '''
 
 
 const String libAngular = '''
-library angular.core.annotation;
+library angular.core.annotation_src;
 
 class AbstractNgAnnotation {
   AbstractNgAnnotation({map: const {}});


### PR DESCRIPTION
Issue was around how the metadata extractor folds member annotations into the class annotations. It was doing in-place modifications to the AST which would then persist to the next build of the application in pub serve. Correct change is to clone the AST node which is to be modified and leave the original intact.
