### PR TITLE
Updating to work on Dart 1.4.0-dev.2

### DIFF
--- a/lib/tools/transformer/expression_generator.dart
+++ b/lib/tools/transformer/expression_generator.dart
@@ -30,8 +30,6 @@ class ExpressionGenerator extends Transformer with ResolverTransformer {
     this.resolvers = resolvers;
   }
 
-  Future<bool> isPrimary(Asset input) => options.isDartEntry(input);
-
   Future applyResolver(Transform transform, Resolver resolver) {
     var asset = transform.primaryInput;
     var outputBuffer = new StringBuffer();

--- a/lib/tools/transformer/metadata_generator.dart
+++ b/lib/tools/transformer/metadata_generator.dart
@@ -16,8 +16,6 @@ class MetadataGenerator extends Transformer with ResolverTransformer {
     this.resolvers = resolvers;
   }
 
-  Future<bool> isPrimary(Asset input) => options.isDartEntry(input);
-
   void applyResolver(Transform transform, Resolver resolver) {
     var asset = transform.primaryInput;
     var id = asset.id;

--- a/lib/tools/transformer/options.dart
+++ b/lib/tools/transformer/options.dart
@@ -42,6 +42,4 @@ class TransformOptions {
     if (sdkDirectory == null)
       throw new ArgumentError('sdkDirectory must be provided.');
   }
-
-  Future<bool> isDartEntry(Asset asset) => isPossibleDartEntry(asset);
 }

--- a/lib/tools/transformer/static_angular_generator.dart
+++ b/lib/tools/transformer/static_angular_generator.dart
@@ -16,8 +16,6 @@ class StaticAngularGenerator extends Transformer with ResolverTransformer {
     this.resolvers = resolvers;
   }
 
-  Future<bool> isPrimary(Asset input) => options.isDartEntry(input);
-
   void applyResolver(Transform transform, Resolver resolver) {
     var asset = transform.primaryInput;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,9 @@ environment:
   sdk: '>=1.2.0'
 dependencies:
   analyzer: '>=0.13.0 <0.14.0'
+  barback: '>=0.11.1 <0.14.0'
   browser: '>=0.10.0 <0.11.0'
-  code_transformers: '>=0.1.0 <0.2.0'
+  code_transformers: '>=0.1.3 <0.2.0'
   collection: '>=0.9.1 <1.0.0'
   di:
     git:


### PR DESCRIPTION
Pub in 1.4 is requiring barback 0.13 which has a breaking change in isPrimary (see https://codereview.chromium.org//223553008). This change allows Angular to target either barback 0.11.1+ or 0.13.0, depending on pub version.

End result is that this allows Angular to work on both stable and dev channel of Dart.

The corresponding DI change is https://github.com/angular/di.dart/pull/83
