### PR TITLE
fix: add docs to NgZone and fix type declaration of onError, onTurnDone

### DIFF
--- a/lib/core/zone.dart
+++ b/lib/core/zone.dart
@@ -133,7 +133,6 @@ class NgZone {
   /**
    * Called with any errors from the inner zone.
    */
-  // We can't initialize onError to _defaultOnError here: dartbug 13519.
   ZoneOnError onError;
   // Prevent silently ignoring uncaught exceptions by forwarding such
   // exceptions to the outer zone.


### PR DESCRIPTION
i think onError, onTurnDone being assignable variables instead of overridable methods makes describing this thing a little wonky
