### PR TITLE
chore(pubspec): Update the SDK constraint to the latest stable version (...

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ authors:
 description: Angular for dart.
 homepage: https://angulardart.org
 environment:
-  sdk: '>=1.2.0'
+  sdk: '>=1.3.0'
 dependencies:
   analyzer: '>=0.13.0 <0.14.0'
   browser: '>=0.10.0 <0.11.0'


### PR DESCRIPTION
...1.3)

Closes #884

**This will not work until a dev version is available for 1.4. As of today it fails with "Package angular requires SDK version >=1.3.0 but the current SDK is 1.3.0-dev.7.12."**
