### PR TITLE
fix(parser): changes parser to throw an error when it encounters an unexpected token

### DIFF
--- a/lib/core/parser/dynamic_parser_impl.dart
+++ b/lib/core/parser/dynamic_parser_impl.dart
@@ -40,6 +40,9 @@ class DynamicParserImpl {
       if (isChain && expr is Filter) {
         error('Cannot have a filter in a chain');
       }
+      if (!isChain && index < tokens.length) {
+        error("'${next}' is an unexpected token", index);
+      }
     }
     return (expressions.length == 1)
         ? expressions.first

--- a/test/core/parser/parser_spec.dart
+++ b/test/core/parser/parser_spec.dart
@@ -194,6 +194,10 @@ main() {
         expectEval("4()").toThrow('4 is not a function');
       });
 
+      it("should throw on an unexpected token", (){
+        expectEval("[1,2] trac")
+            .toThrow('Parser Error: \'trac\' is an unexpected token at column 7 in [[1,2] trac]');
+      });
 
       it('should fail gracefully when invoking non-function', () {
         expect(() {


### PR DESCRIPTION
Change the handling of unexpected tokens. Make the parser throw the "is an unexpected token" exception, so ExpressionVisitor won't throw confusing "Can not watch expression containing ';'".

Closes #830
