### PR TITLE
refactor(WatchGroup): remove an interface

### DIFF
--- a/lib/change_detection/watch_group.dart
+++ b/lib/change_detection/watch_group.dart
@@ -702,7 +702,7 @@ class _InvokeHandler extends _Handler implements _ArgHandlerList {
 }
 
 
-class _EvalWatchRecord implements WatchRecord<_Handler>, Record<_Handler> {
+class _EvalWatchRecord implements WatchRecord<_Handler> {
   static const int _MODE_INVALID_             = -2;
   static const int _MODE_DELETED_             = -1;
   static const int _MODE_MARKER_              = 0;


### PR DESCRIPTION
WatchGroup does not need to implement both WatchRecord<H> and Record<H>
because WatchRecord<H> extends Record<H>.
