### PR TITLE
fix(transformer): Fixing invalid code generation for dashed filenames

### DIFF
--- a/lib/tools/transformer/expression_generator.dart
+++ b/lib/tools/transformer/expression_generator.dart
@@ -133,6 +133,7 @@ class ExpressionGenerator extends Transformer with ResolverTransformer {
 
 void _writeStaticExpressionHeader(AssetId id, StringSink sink) {
   var libPath = path.withoutExtension(id.path).replaceAll('/', '.');
+  libPath = libPath.replaceAll('-', '_');
   sink.write('''
 library ${id.package}.$libPath.generated_expressions;
 

--- a/lib/tools/transformer/metadata_generator.dart
+++ b/lib/tools/transformer/metadata_generator.dart
@@ -71,6 +71,7 @@ class MetadataGenerator extends Transformer with ResolverTransformer {
 
 void _writeHeader(AssetId id, StringSink sink) {
   var libPath = path.withoutExtension(id.path).replaceAll('/', '.');
+  libPath = libPath.replaceAll('-', '_');
   sink.write('''
 library ${id.package}.$libPath.generated_metadata;
 


### PR DESCRIPTION
When entry point dart filenames contained dashes then the generated library name was incorrect.

This is to address https://github.com/angular/angular.dart/issues/947
