### PR TITLE
angular.mock: better documentation.

### DIFF
--- a/lib/mock/test_injection.dart
+++ b/lib/mock/test_injection.dart
@@ -73,11 +73,14 @@ class _SpecInjector {
  *
  * NOTE: Calling inject creates an injector, which prevents any more calls to [module].
  *
+ * NOTE: [inject] will never return the result of [fn]. If you need to return a [Future]
+ * for unittest to consume, take a look at [async], [clockTick], and [microLeap] instead.
+ *
  * Typical usage:
  *
  *     test('wrap whole test', inject((TestBed tb) {
  *       tb.compile(...);
- *     });
+ *     }));
  *
  *     test('wrap part of a test', () {
  *       module((Module module) {

--- a/lib/mock/zone.dart
+++ b/lib/mock/zone.dart
@@ -18,8 +18,15 @@ final _asyncErrors = [];
 bool _noMoreAsync = false;
 
 /**
- * Runs any queued up async calls and any async calls queued with
- * running microLeap. Example:
+ * Processes the asynchronous queue established by [async].
+ *
+ * [microLeap] will process all items in the asynchronous queue,
+ * including new items queued during its execution. It will re-raise
+ * any exceptions that occur.
+ *
+ * NOTE: [microLeap] can only be used in [async] tests.
+ *
+ * Example:
  *
  *     it('should run async code', async(() {
  *       var thenRan = false;
@@ -146,7 +153,16 @@ noMoreAsync() {
 }
 
 /**
- * Captures all scheduleMicrotask calls inside of a function.
+ * Captures all scheduleMicrotask calls and newly created Timers
+ * inside of a function.
+ *
+ * [async] will raise an exception if there are still active Timers
+ * when the function completes.
+ *
+ * Use [clockTick] to process timers, and [microLeap] to process
+ * scheduleMicrotask calls.
+ *
+ * NOTE: [async] will not return the result of [fn].
  *
  * Typically used within a test:
  *


### PR DESCRIPTION
Make the documentation for inject, async, and microLeap more clear. Made
sure to note that neither inject nor async return their functions
values, as it is (seems?) common to do this in unittest when testing
time-dependent functionality using `Future.delayed` or `Timer.`

Fixes #943
