### PR TITLE
fix(codegen): Add missing @Injectable annotation

### DIFF
--- a/lib/core_dom/transcluding_component_factory.dart
+++ b/lib/core_dom/transcluding_component_factory.dart
@@ -62,6 +62,7 @@ class ContentPort {
   }
 }
 
+@Injectable()
 class TranscludingComponentFactory implements ComponentFactory {
   final Expando _expando;
 


### PR DESCRIPTION
DI setup is done in lib/core_dom/module_internal.dart. Required as a ctor param for ElementBinderFactory.
