### PR TITLE
chore(pubspec): Replace shadow_dom with web_components

### DIFF
--- a/benchmark/pubspec.lock
+++ b/benchmark/pubspec.lock
@@ -10,7 +10,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.11.0"
   args:
     description: args
     source: hosted
@@ -18,7 +18,7 @@ packages:
   barback:
     description: barback
     source: hosted
-    version: "0.12.0"
+    version: "0.13.0"
   benchmark_harness:
     description: benchmark_harness
     source: hosted
@@ -34,7 +34,7 @@ packages:
   collection:
     description: collection
     source: hosted
-    version: "0.9.1"
+    version: "0.9.2"
   di:
     description: di
     source: hosted
@@ -46,7 +46,7 @@ packages:
   intl:
     description: intl
     source: hosted
-    version: "0.9.8"
+    version: "0.9.9"
   logging:
     description: logging
     source: hosted
@@ -70,11 +70,7 @@ packages:
   route_hierarchical:
     description: route_hierarchical
     source: hosted
-    version: "0.4.19"
-  shadow_dom:
-    description: shadow_dom
-    source: hosted
-    version: "0.9.2"
+    version: "0.4.20"
   source_maps:
     description: source_maps
     source: hosted
@@ -91,3 +87,7 @@ packages:
     description: utf
     source: hosted
     version: "0.9.0"
+  web_components:
+    description: web_components
+    source: hosted
+    version: "0.3.3"

--- a/benchmark/pubspec.yaml
+++ b/benchmark/pubspec.yaml
@@ -1,30 +1,9 @@
 name: angular-perf
-version: 0.9.10
-authors:
-- Misko Hevery <misko@hevery.com>
-- Pavel Jbanov <pavelgj@gmail.com>
-- James deBoer <james@huronbox.com>
-- Chirayu Krishnappa <chirayu@google.com>
-- Matias Niemela <matias@yearofmoo.com>
-- Paul Rohde <paul@paulrohde.com>
-- Victor Berchet <victor@suumit.com>
-description: Angular for dart.
-homepage: https://angulardart.org
-environment:
-  sdk: '>=1.2.0'
+version: 0.10.0
+description: Angular benchmarks
 dependencies:
   angular:
     path: ..
-  analyzer: '>=0.13.0 <0.14.0'
-  browser: '>=0.10.0 <0.11.0'
-  code_transformers: '>=0.1.0 <0.2.0'
-  collection: '>=0.9.1 <1.0.0'
-  di: '>=0.0.37 <0.1.0'
-  html5lib: '>=0.10.0 <0.11.0'
-  intl: '>=0.8.7 <0.10.0'
-  perf_api: '>=0.0.8 <0.1.0'
-  route_hierarchical: '>=0.4.7 <0.5.0'
-  shadow_dom: '>=0.9.1 <1.0.0'
 dev_dependencies:
   benchmark_harness: '>=1.0.0'
   unittest: '>=0.10.1 <0.12.0'

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -10,7 +10,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.10.0"
+    version: "0.11.0"
   args:
     description: args
     source: hosted
@@ -30,7 +30,7 @@ packages:
   collection:
     description: collection
     source: hosted
-    version: "0.9.1"
+    version: "0.9.2"
   di:
     description: di
     source: hosted
@@ -38,11 +38,11 @@ packages:
   html5lib:
     description: html5lib
     source: hosted
-    version: "0.9.2"
+    version: "0.10.0"
   intl:
     description: intl
     source: hosted
-    version: "0.9.8"
+    version: "0.9.9"
   logging:
     description: logging
     source: hosted
@@ -66,11 +66,7 @@ packages:
   route_hierarchical:
     description: route_hierarchical
     source: hosted
-    version: "0.4.19"
-  shadow_dom:
-    description: shadow_dom
-    source: hosted
-    version: "0.9.2"
+    version: "0.4.20"
   source_maps:
     description: source_maps
     source: hosted
@@ -87,3 +83,7 @@ packages:
     description: utf
     source: hosted
     version: "0.9.0"
+  web_components:
+    description: web_components
+    source: hosted
+    version: "0.3.3"

--- a/karma-perf.conf.js
+++ b/karma-perf.conf.js
@@ -8,12 +8,13 @@ module.exports = function(config) {
     // all tests must be 'included', but all other libraries must be 'served' and
     // optionally 'watched' only.
     files: [
+      'packages/web_components/platform.js',
+      'packages/web_components/dart_support.js',
       'benchmark/dom/*.dart',
       'benchmark/*_perf.dart',
       'test/config/init_guinness.dart',
       {pattern: '**/*.dart', watched: true, included: false, served: true},
-      'packages/browser/dart.js',
-      'packages/browser/interop.js'
+      'packages/browser/dart.js'
     ],
 
     autoWatch: false,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,13 +8,13 @@ module.exports = function(config) {
     // all tests must be 'included', but all other libraries must be 'served' and
     // optionally 'watched' only.
     files: [
+      'packages/web_components/platform.js',
+      'packages/web_components/dart_support.js',
       'test/*.dart',
       'test/**/*_spec.dart',
       'test/config/init_guinness.dart',
       {pattern: '**/*.dart', watched: true, included: false, served: true},
-      'packages/browser/dart.js',
-      'packages/browser/interop.js',
-      'packages/shadow_dom/shadow_dom.debug.js'
+      'packages/browser/dart.js'
     ],
 
     exclude: [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -69,10 +69,6 @@ packages:
     description: route_hierarchical
     source: hosted
     version: "0.4.20"
-  shadow_dom:
-    description: shadow_dom
-    source: hosted
-    version: "0.10.0"
   source_maps:
     description: source_maps
     source: hosted
@@ -89,3 +85,7 @@ packages:
     description: utf
     source: hosted
     version: "0.9.0"
+  web_components:
+    description: web_components
+    source: hosted
+    version: "0.3.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   intl: '>=0.8.7 <0.10.0'
   perf_api: '>=0.0.8 <0.1.0'
   route_hierarchical: '>=0.4.18 <0.5.0'
-  shadow_dom: '>=0.9.1 <1.0.0'
+  web_components: '>=0.3.3 <0.4.0'
 dev_dependencies:
   benchmark_harness: '>=1.0.0'
   unittest: '>=0.10.1 <0.12.0'


### PR DESCRIPTION
The shadow_dom package is deprecated, see
https://code.google.com/p/dart/issues/detail?id=18080

see also https://github.com/angular/angular.dart/issues/956#issuecomment-41579957
