### PR TITLE
feat(VmTurnZone): VmTurnZone can handle scheduling microtasks.

### DIFF
--- a/lib/core/zone.dart
+++ b/lib/core/zone.dart
@@ -11,6 +11,12 @@ typedef void ZoneOnTurnDone();
 typedef void ZoneOnTurnStart();
 
 /**
+ * Handles a [VmTurnZone] defaultOnScheduleMicrotask.
+ */
+typedef void ZoneScheduleMicrotask(async.Zone self, async.ZoneDelegate delegate, async.Zone zone,
+                                   fn());
+
+/**
  * Handles a [VmTurnZone] onError event.
  */
 typedef void ZoneOnError(dynamic error, dynamic stacktrace,
@@ -59,6 +65,11 @@ class VmTurnZone {
   async.Zone _innerZone;
 
   /**
+   *
+   */
+  ZoneScheduleMicrotask onScheduleMicrotask;
+
+  /**
    * Associates with this
    *
    * - an "outer" [Zone], which is the one that created this.
@@ -78,6 +89,7 @@ class VmTurnZone {
     onError = _defaultOnError;
     onTurnDone = _defaultOnTurnDone;
     onTurnStart = _defaultOnTurnStart;
+    onScheduleMicrotask = _defaultOnScheduleMicrotask;
   }
 
   List _asyncQueue = [];
@@ -111,6 +123,11 @@ class VmTurnZone {
 
   _onScheduleMicrotask(async.Zone self, async.ZoneDelegate delegate,
                        async.Zone zone, fn()) {
+    onScheduleMicrotask(self, delegate, zone, fn);
+  }
+
+  _defaultOnScheduleMicrotask(async.Zone self, async.ZoneDelegate delegate,
+                              async.Zone zone, fn()) {
     _asyncQueue.add(() => delegate.run(zone, fn));
     if (_runningInTurn == 0 && !_inFinishTurn)  _finishTurn(zone, delegate);
   }

--- a/test/core/zone_spec.dart
+++ b/test/core/zone_spec.dart
@@ -435,5 +435,112 @@ void main() {
         microLeap();
       })).toThrow('ssertion');  // Support both dart2js and the VM with half a word.
     });
+
+    group('microtask scheduler', () {
+
+      it('should execute microtask scheduled in onTurnDone before onTurnDone is complete',
+          async((Logger log) {
+        var microtaskResult = false;
+        zone.onTurnStart = () {
+          log('onTurnStart');
+        };
+        zone.onTurnDone = () {
+          log('onTurnDone(begin)');
+          scheduleMicrotask(() {
+            log('executeMicrotask');
+            return true;
+          });
+          log('onTurnDone(end)');
+        };
+        zone.onScheduleMicrotask = (_, __, ___, microTaskFn) {
+          log('onScheduleMicrotask(begin)');
+          microtaskResult = microTaskFn();
+          log('onScheduleMicrotask(end)');
+        };
+        zone.run(() {
+          log('run');
+        });
+
+        expect(log.result()).toEqual('onTurnStart; run; onTurnDone(begin); '
+          'onScheduleMicrotask(begin); executeMicrotask; onScheduleMicrotask(end); onTurnDone(end)'
+        );
+        expect(microtaskResult).toBeTruthy();
+      }));
+
+      it('should work with future scheduled in onTurnDone', async((Logger log) {
+        zone.onTurnStart = () {
+          log('onTurnStart');
+        };
+        zone.onTurnDone = () {
+          log('onTurnDone(begin)');
+          new Future.value('async').then((v) {
+            log('executed ${v}');
+          });
+          log('onTurnDone(end)');
+        };
+        zone.onScheduleMicrotask = (_, __, ___, microTaskFn) {
+          log('onScheduleMicrotask(begin)');
+          microTaskFn();
+          log('onScheduleMicrotask(end)');
+        };
+        zone.run(() {
+          log('run');
+        });
+
+        expect(log.result()).toEqual('onTurnStart; run; onTurnDone(begin); '
+          'onScheduleMicrotask(begin); onScheduleMicrotask(end); onScheduleMicrotask(begin);'
+          ' executed async; onScheduleMicrotask(end); onTurnDone(end)');
+      }));
+
+      it('should execute microtask scheduled in run before onTurnDone starts',
+        async((Logger log) {
+        zone.onTurnStart = () {
+          log('onTurnStart');
+        };
+        zone.onTurnDone = () {
+          log('onTurnDone');
+        };
+        zone.onScheduleMicrotask = (_, __, ___, microTaskFn) {
+          log('onScheduleMicrotask(begin)');
+          microTaskFn();
+          log('onScheduleMicrotask(end)');
+        };
+        zone.run(() {
+          log('run');
+          scheduleMicrotask(() {
+            log('executeMicrotask');
+            return true;
+          });
+        });
+
+        expect(log.result()).toEqual('onTurnStart; run; onScheduleMicrotask(begin);'
+          ' executeMicrotask; onScheduleMicrotask(end); onTurnDone');
+      }));
+
+      it('should execute microtask scheduled in onTurnStart before run',
+        async((Logger log) {
+        zone.onTurnStart = () {
+          log('onTurnStart');
+          scheduleMicrotask(() {
+            log('executeMicrotask');
+          });
+        };
+        zone.onTurnDone = () {
+          log('onTurnDone');
+        };
+        zone.onScheduleMicrotask = (_, __, ___, microTaskFn) {
+          log('onScheduleMicrotask(begin)');
+          microTaskFn();
+          log('onScheduleMicrotask(end)');
+        };
+        zone.run(() {
+          log('run');
+        });
+
+        expect(log.result()).toEqual('onTurnStart; onScheduleMicrotask(begin); executeMicrotask;'
+          ' onScheduleMicrotask(end); run; onTurnDone');
+      }));
+
+    });
   });
 }


### PR DESCRIPTION
To customize how VmTurnZone handles microtasks assign a function to
VmTurnZone.onScheduleMicrotask. This method will then be used whenever
a microtask is scheduled instead of the default implementation.

Closes #976
