### PR TITLE
fix(Dirty Checking): fix method detection and calling

### DIFF
--- a/lib/change_detection/change_detection.dart
+++ b/lib/change_detection/change_detection.dart
@@ -174,9 +174,6 @@ typedef dynamic FieldGetter(object);
 typedef void FieldSetter(object, value);
 
 abstract class FieldGetterFactory {
-  get isMethodInvoke;
-  bool isMethod(Object object, String name);
-  Function method(Object object, String name);
   FieldGetter getter(Object object, String name);
 }
 

--- a/lib/change_detection/dirty_checking_change_detector.dart
+++ b/lib/change_detection/dirty_checking_change_detector.dart
@@ -373,11 +373,13 @@ class DirtyCheckingRecord<H> implements Record<H>, WatchRecord<H> {
   static const List<String> _MODE_NAMES =
       const ['MARKER', 'IDENT', 'GETTER', 'MAP[]', 'ITERABLE', 'MAP'];
   static const int _MODE_MARKER_ = 0;
-  static const int _MODE_IDENTITY_ = 1;
-  static const int _MODE_GETTER_ = 2;
-  static const int _MODE_MAP_FIELD_ = 3;
-  static const int _MODE_ITERABLE_ = 4;
-  static const int _MODE_MAP_ = 5;
+  static const int _MODE_NOOP_ = 1;
+  static const int _MODE_IDENTITY_ = 2;
+  static const int _MODE_GETTER_ = 3;
+  static const int _MODE_GETTER_OR_METHOD_CLOSURE_ = 4;
+  static const int _MODE_MAP_FIELD_ = 5;
+  static const int _MODE_ITERABLE_ = 6;
+  static const int _MODE_MAP_ = 7;
 
   final DirtyCheckingChangeDetectorGroup _group;
   final FieldGetterFactory _fieldGetterFactory;
@@ -460,7 +462,7 @@ class DirtyCheckingRecord<H> implements Record<H>, WatchRecord<H> {
       _mode =  _MODE_MAP_FIELD_;
       _getter = null;
     } else {
-      _mode = _MODE_GETTER_;
+      _mode = _MODE_GETTER_OR_METHOD_CLOSURE_;
       _getter = _fieldGetterFactory.getter(obj, field);
     }
   }
@@ -471,14 +473,30 @@ class DirtyCheckingRecord<H> implements Record<H>, WatchRecord<H> {
     switch (_mode) {
       case _MODE_MARKER_:
         return false;
+      case _MODE_NOOP_:
+        return false;
       case _MODE_GETTER_:
         current = _getter(object);
+        break;
+      case _MODE_GETTER_OR_METHOD_CLOSURE_:
+        // NOTE: When Dart looks up a method "foo" on object "x", it returns a
+        // new closure for each lookup.  They compare equal via "==" but are no
+        // identical().  There's no point getting a new value each time and
+        // decide it's the same so we'll skip further checking after the first
+        // time.
+        current = _getter(object);
+        if (current is Function && !identical(current, _getter(object))) {
+          _mode = _MODE_NOOP_;
+        } else {
+          _mode = _MODE_GETTER_;
+        }
         break;
       case _MODE_MAP_FIELD_:
         current = object[field];
         break;
       case _MODE_IDENTITY_:
         current = object;
+        _mode = _MODE_NOOP_;
         break;
       case _MODE_MAP_:
         return (currentValue as _MapChangeRecord)._check(object);

--- a/lib/change_detection/dirty_checking_change_detector_dynamic.dart
+++ b/lib/change_detection/dirty_checking_change_detector_dynamic.dart
@@ -11,26 +11,9 @@ export 'package:angular/change_detection/change_detection.dart' show
 import 'dart:mirrors';
 
 class DynamicFieldGetterFactory implements FieldGetterFactory {
-  final isMethodInvoke = true;
-
-  bool isMethod(Object object, String name) {
-    try {
-      return method(object, name) != null;
-    } catch (e, s) {
-      return false;
-    }
-  }
-
-  Function method(Object object, String name) {
-    Symbol symbol = new Symbol(name);
-    InstanceMirror instanceMirror = reflect(object);
-    return (List args, Map namedArgs) =>
-        instanceMirror.invoke(symbol, args, namedArgs).reflectee;
-  }
-
   FieldGetter getter(Object object, String name) {
     Symbol symbol = new Symbol(name);
     InstanceMirror instanceMirror = reflect(object);
-    return (Object object) =>  instanceMirror.getField(symbol).reflectee;
+    return (Object object) => instanceMirror.getField(symbol).reflectee;
   }
 }

--- a/lib/change_detection/dirty_checking_change_detector_static.dart
+++ b/lib/change_detection/dirty_checking_change_detector_static.dart
@@ -3,30 +3,13 @@ library dirty_checking_change_detector_static;
 import 'package:angular/change_detection/change_detection.dart';
 
 class StaticFieldGetterFactory implements FieldGetterFactory {
-  final isMethodInvoke = false;
   Map<String, FieldGetter> getters;
 
   StaticFieldGetterFactory(this.getters);
-
-  bool isMethod(Object object, String name) {
-    // We need to know if we are referring to method or field which is a
-    // function. We can find out by calling it twice and seeing if we get
-    // the same value. Methods create a new closure each time.
-    FieldGetter getterFn = getter(object, name);
-    dynamic property = getterFn(object);
-    return (property is Function) &&
-           (!identical(property, getterFn(object)));
-  }
 
   FieldGetter getter(Object object, String name) {
     var getter = getters[name];
     if (getter == null) throw "Missing getter: (o) => o.$name";
     return getter;
-  }
-
-  Function method(Object object, String name) {
-    var method = getters[name];
-    if (method == null) throw "Missing method: $name";
-    return method;
   }
 }

--- a/test/directive/ng_repeat_spec.dart
+++ b/test/directive/ng_repeat_spec.dart
@@ -116,6 +116,16 @@ main() {
       expect(element.querySelectorAll('span').length).toEqual(2);
     });
 
+    it('should support function as a formatter', () {
+      scope.context['isEven'] = (num) => num % 2 == 0;
+      var element = compile(
+          '<div ng-show="true">'
+            '<span ng-repeat="r in [1, 2] | filter:isEven">{{r}}</span>'
+          '</div>');
+      scope.apply();
+      expect(element.text).toEqual('2');
+    });
+
 
     describe('track by', () {
       it(r'should track using expression function', () {


### PR DESCRIPTION
- run tests against `StaticFieldGetterFactory`
- do not call the result of `GetterFactory.method()`
  in `set object(value)`
- reduce the difference between the two (get rid of
  `_MODE_METHOD_INVOKE_`)
