### PR TITLE
test(travis): Disable dart2js/dev tests due to a bug in dart2js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,10 @@ env:
   - JOB=unit-stable
     CHANNEL=stable
     TESTS=dart2js
-  - JOB=unit-dev
-    CHANNEL=DEV
-    TESTS=dart2js
+# See https://code.google.com/p/dart/issues/detail?id=13523
+#  - JOB=unit-dev
+#    CHANNEL=DEV
+#    TESTS=dart2js
   global:
   - CHROME_BIN=/usr/bin/google-chrome
   - secure: "AKoqpZ699egF0i4uT/FQ5b4jIc0h+KVbhtVCql0uFxwFIl2HjOYgDayrUCAf6USfpW0LghZxJJhBamWOl/505eNSe9HvEd8JLg/to+1Fo9xi9llsu5ehmNH31/5pue4EvsrVuEap1qqL6/BNwI2cAryayU0p5tV0g8gL5h4IxG8="


### PR DESCRIPTION
see:
- bug: https://code.google.com/p/dart/issues/detail?id=13523
- failure: https://travis-ci.org/angular/angular.dart/jobs/24455215

This bug is quite old but as explained by @chirayuk in the bug report comments but [this commit](https://github.com/chirayuk/angular.dart/commit/68db30b34a873952d914e73b8a58e48857d6cc8e#diff-9df6a774fe4890fa9b478821b35688fdR1294) triggers it.

_(This should be reverted when the bug gets fixed)_
