### PR TITLE
fix(ng-repeat): handle the ref changing to null and back

### DIFF
--- a/test/directive/ng_repeat_spec.dart
+++ b/test/directive/ng_repeat_spec.dart
@@ -107,6 +107,33 @@ main() {
     });
 
 
+    it('should gracefully handle ref changing to null and back', () {
+      scope.context['items'] = ['odin', 'dva',];
+      element = compile(
+        '<div>'
+          '<ul>'
+            '<li ng-repeat="item in items">{{item}};</li>'
+          '</ul>'
+        '</div>');
+      scope.apply();
+      expect(element.querySelectorAll('ul').length).toEqual(1);
+      expect(element.querySelectorAll('li').length).toEqual(2);
+      expect(element.text).toEqual('odin;dva;');
+
+      scope.context['items'] = null;
+      scope.apply();
+      expect(element.querySelectorAll('ul').length).toEqual(1);
+      expect(element.querySelectorAll('li').length).toEqual(0);
+      expect(element.text).toEqual('');
+
+      scope.context['items'] = ['odin', 'dva', 'tri'];
+      scope.apply();
+      expect(element.querySelectorAll('ul').length).toEqual(1);
+      expect(element.querySelectorAll('li').length).toEqual(3);
+      expect(element.text).toEqual('odin;dva;tri;');
+    });
+
+
     it('should support formatters', () {
       element = compile(
           '<div><span ng-repeat="item in items | filter:myFilter">{{item}}</span></div>');


### PR DESCRIPTION
This was broken in commit 09871cb29b5345d49929895b2a490360eee69244.

If the ng-repeat expression changed from an iterable to a null,
ng-repeat would not notice it.  This would cause further bugs as it
would not reset its state and the ref became a collection again (i.e.
once out of sync, it was gone forever.)

Closes #1015
