### PR TITLE
chore(Travis): tweak build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,26 @@
 language: node_js
 node_js:
 - "0.11"
-addons:
-  firefox: "28.0"
 env:
   matrix:
   - JOB=unit-dev
-    CHANNEL=DEV
+    CHANNEL=dev
     TESTS=dart2js
+    BROWSERS=ChromeNoSandbox,Firefox
   - JOB=unit-dev
     CHANNEL=dev
     TESTS=vm
+    BROWSERS=Dartium
   - JOB=unit-stable
     CHANNEL=stable
     TESTS=dart2js
+    BROWSERS=ChromeNoSandbox,Firefox
   - JOB=unit-stable
     CHANNEL=stable
     TESTS=vm
+    BROWSERS=Dartium
   global:
+  - FIREFOX_VERSION="29.0"
   - CHROME_BIN=/usr/bin/google-chrome
   - secure: "AKoqpZ699egF0i4uT/FQ5b4jIc0h+KVbhtVCql0uFxwFIl2HjOYgDayrUCAf6USfpW0LghZxJJhBamWOl/505eNSe9HvEd8JLg/to+1Fo9xi9llsu5ehmNH31/5pue4EvsrVuEap1qqL6/BNwI2cAryayU0p5tV0g8gL5h4IxG8="
 

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -91,13 +91,6 @@ else
   )
 fi
 
-BROWSERS=Dartium,ChromeNoSandbox,FireFox
-if [[ $TESTS == "dart2js" ]]; then
-  BROWSERS=ChromeNoSandbox,Firefox;
-elif [[ $TESTS == "vm" ]]; then
-  BROWSERS=Dartium;
-fi
-
 echo '-----------------------'
 echo '-- TEST: AngularDart --'
 echo '-----------------------'

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -1,15 +1,40 @@
 #!/bin/bash
 
-set -exv
+set -e
 
 sh -e /etc/init.d/xvfb start
-sudo apt-get update -qq
-sudo apt-get install -qq unzip chromium-browser
-sudo apt-get install libxss1
 
-if [[ $TESTS != "vm" ]]; then
-  wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb;
-  dpkg -I google-chrome*.deb;
-  sudo dpkg -i google-chrome*.deb;
-  sudo chmod u+s /opt;
+DARTIUM_ZIP=http://storage.googleapis.com/dart-archive/channels/$CHANNEL/raw/latest/dartium/dartium-linux-x64-release.zip
+FF_TAR=http://ftp.mozilla.org/pub/mozilla.org/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2
+CHROME_DEB=https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+
+shopt -s nocasematch
+
+if [[ $BROWSERS =~ "dartium" ]]; then
+  echo "Installing Dartium from $DARTIUM_ZIP"
+  curl $DARTIUM_ZIP > dartium.zip
+  unzip dartium.zip > /dev/null
+  rm -rf dartium
+  rm dartium.zip
+  mv dartium-* dartium
+fi
+
+if [[ $BROWSERS =~ "chrome" ]]; then
+  echo "Installing Chrome from $CHROME_DEB"
+  wget $CHROME_DEB
+  dpkg -I google-chrome*.deb
+  sudo dpkg -i google-chrome*.deb
+  sudo chmod u+s /opt
+fi
+
+if [[ $BROWSERS =~ "firefox" ]]; then
+  echo "Installing Firefox from $FF_TAR"
+  sudo mkdir -p /usr/local/firefox-$FIREFOX_VERSION
+  sudo chmod u+s /usr/local/firefox-$FIREFOX_VERSION
+  wget -O /tmp/firefox.tar.bz2 $FF_TAR
+  cd /usr/local/firefox-$FIREFOX_VERSION
+  sudo tar xf /tmp/firefox.tar.bz2
+  sudo ln -sf /usr/local/firefox-$FIREFOX_VERSION/firefox/firefox /usr/local/bin/firefox
+  sudo ln -sf /usr/local/firefox-$FIREFOX_VERSION/firefox/firefox-bin /usr/local/bin/firefox-bin
+  export FIREFOX_BIN=/usr/local/bin/firefox
 fi

--- a/scripts/travis/setup.sh
+++ b/scripts/travis/setup.sh
@@ -2,35 +2,16 @@
 
 set -e
 
-case $( uname -s ) in
-  Linux)
-    DART_SDK_ZIP=dartsdk-linux-x64-release.zip
-    DARTIUM_ZIP=dartium-linux-x64-release.zip
-    ;;
-  Darwin)
-    DART_SDK_ZIP=dartsdk-macos-x64-release.zip
-    DARTIUM_ZIP=dartium-macos-ia32-release.zip
-    ;;
-esac
 
-CHANNEL=`echo $JOB | cut -f 2 -d -`
 echo Fetch Dart channel: $CHANNEL
+
+DART_SDK_ZIP=dartsdk-linux-x64-release.zip
 
 echo http://storage.googleapis.com/dart-archive/channels/$CHANNEL/release/latest/sdk/$DART_SDK_ZIP
 curl http://storage.googleapis.com/dart-archive/channels/$CHANNEL/release/latest/sdk/$DART_SDK_ZIP > $DART_SDK_ZIP
 echo Fetched new dart version $(unzip -p $DART_SDK_ZIP dart-sdk/version)
 rm -rf dart-sdk
 unzip $DART_SDK_ZIP > /dev/null
-rm $DART_SDK_ZIP
-
-if [[ $TESTS != "dart2js" ]]; then
-  echo http://storage.googleapis.com/dart-archive/channels/$CHANNEL/raw/latest/dartium/$DARTIUM_ZIP
-  curl http://storage.googleapis.com/dart-archive/channels/$CHANNEL/raw/latest/dartium/$DARTIUM_ZIP > $DARTIUM_ZIP
-  unzip $DARTIUM_ZIP > /dev/null
-  rm -rf dartium
-  rm $DARTIUM_ZIP
-  mv dartium-* dartium;
-fi
 
 echo =============================================================================
 . ./scripts/env.sh


### PR DESCRIPTION
The builds should be marginally faster (install FF when required, do not apt-get chromium) and it saves some BW for travis servers.
