### PR TITLE
chore(testing): upgrade guinness

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -36,7 +36,7 @@ packages:
   guinness:
     description: guinness
     source: hosted
-    version: "0.1.2"
+    version: "0.1.3"
   html5lib:
     description: html5lib
     source: hosted

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,4 +29,4 @@ dev_dependencies:
   benchmark_harness: '>=1.0.0'
   unittest: '>=0.10.1 <0.12.0'
   mock: '>=0.10.0 <0.12.0'
-  guinness: '>=0.1.1 <0.2.0'
+  guinness: '>=0.1.3 <0.2.0'


### PR DESCRIPTION
Upgrade the Guinness library to fix the issue with `ddescribe` not working.

Closes #1029
