### PR TITLE
fix(compiler): Do not store injectors with TaggingElementBinders

### DIFF
--- a/lib/core_dom/element_binder.dart
+++ b/lib/core_dom/element_binder.dart
@@ -403,7 +403,6 @@ class TaggedTextBinder {
 class TaggedElementBinder {
   final ElementBinder binder;
   int parentBinderOffset;
-  var injector;
   bool isTopLevel;
 
   List<TaggedTextBinder> textBinders;
@@ -416,6 +415,5 @@ class TaggedElementBinder {
   }
 
   String toString() => "[TaggedElementBinder binder:$binder parentBinderOffset:"
-                       "$parentBinderOffset textBinders:$textBinders "
-                       "injector:$injector]";
+                       "$parentBinderOffset textBinders:$textBinders]";
 }


### PR DESCRIPTION
TaggingElementBinders are long-lived objects and the injectors are
specific to a View.  By storing injectors, Angular is retaining more
memory than needed.

With this change, injectors are local to a ViewFactory.call() invocation.
