### PR TITLE
fix(Http): Auxiliary methods like get, put, post, etc. do not set type r...

### DIFF
--- a/lib/core_dom/http.dart
+++ b/lib/core_dom/http.dart
@@ -421,7 +421,7 @@ class Http {
   async.Future<HttpResponse> call({
     String url,
     String method,
-    data,
+    dynamic data,
     Map<String, dynamic> params,
     Map<String, dynamic> headers,
     bool withCredentials: false,
@@ -455,8 +455,6 @@ class Http {
     });
 
     var serverRequest = (HttpResponseConfig config) {
-      assert(config.data == null || config.data is String || config.data is dom.File);
-
       // Strip content-type if data is undefined
       if (config.data == null) {
         new List.from(headers.keys)
@@ -536,7 +534,6 @@ class Http {
    * of parameters.
    */
   async.Future<HttpResponse> get(String url, {
-    String data,
     Map<String, dynamic> params,
     Map<String, String> headers,
     bool withCredentials: false,
@@ -545,7 +542,7 @@ class Http {
     interceptors,
     cache,
     timeout
-  }) => call(method: 'GET', url: url, data: data, params: params, headers: headers,
+  }) => call(method: 'GET', url: url, data: null, params: params, headers: headers,
              withCredentials: withCredentials, xsrfHeaderName: xsrfHeaderName,
              xsrfCookieName: xsrfCookieName, interceptors: interceptors, cache: cache,
              timeout: timeout);
@@ -555,7 +552,7 @@ class Http {
    * of parameters.
    */
   async.Future<HttpResponse> delete(String url, {
-    String data,
+    dynamic data,
     Map<String, dynamic> params,
     Map<String, String> headers,
     bool withCredentials: false,
@@ -574,7 +571,7 @@ class Http {
    * of parameters.
    */
   async.Future<HttpResponse> head(String url, {
-    String data,
+    dynamic data,
     Map<String, dynamic> params,
     Map<String, String> headers,
     bool withCredentials: false,
@@ -592,7 +589,7 @@ class Http {
    * Shortcut method for PUT requests.  See [call] for a complete description
    * of parameters.
    */
-  async.Future<HttpResponse> put(String url, String data, {
+  async.Future<HttpResponse> put(String url, dynamic data, {
     Map<String, dynamic> params,
     Map<String, String> headers,
     bool withCredentials: false,
@@ -610,7 +607,7 @@ class Http {
    * Shortcut method for POST requests.  See [call] for a complete description
    * of parameters.
    */
-  async.Future<HttpResponse> post(String url, String data, {
+  async.Future<HttpResponse> post(String url, dynamic data, {
     Map<String, dynamic> params,
     Map<String, String> headers,
     bool withCredentials: false,
@@ -629,7 +626,7 @@ class Http {
    * of parameters.
    */
   async.Future<HttpResponse> jsonp(String url, {
-    String data,
+    dynamic data,
     Map<String, dynamic> params,
     Map<String, String> headers,
     bool withCredentials: false,


### PR DESCRIPTION
1. Methods Get, Put, Post, Head, Jsonp don't set type restriction on data parameter.
2. Get does not take data parameter.

Fixes #1062 
