### PR TITLE
refactor(NgView): Make use of the ViewPort

### DIFF
--- a/lib/mock/test_bed.dart
+++ b/lib/mock/test_bed.dart
@@ -8,7 +8,7 @@ part of angular.mock;
  */
 class TestBed {
   final Injector injector;
-  final Scope rootScope;
+  final RootScope rootScope;
   final Compiler compiler;
   final Parser _parser;
   final Expando expando;

--- a/test/routing/ng_view_spec.dart
+++ b/test/routing/ng_view_spec.dart
@@ -28,27 +28,30 @@ main() {
 
 
     it('should switch template', async(() {
-      Element root = _.compile('<ng-view></ng-view>');
+      Element root = _.compile('<div><ng-view></ng-view></div>');
       expect(root.text).toEqual('');
 
       router.route('/foo');
       microLeap();
+      _.rootScope.flush();
       expect(root.text).toEqual('Foo');
 
       router.route('/bar');
       microLeap();
+      _.rootScope.flush();
       expect(root.text).toEqual('Bar');
 
       router.route('/foo');
       microLeap();
+      _.rootScope.flush();
       expect(root.text).toEqual('Foo');
     }));
 
     it('should expose NgView as RouteProvider', async(() {
-      _.compile('<ng-view probe="m"></ng-view>');
+      _.compile('<div><ng-view probe="m"></ng-view></div>');
       router.route('/foo');
       microLeap();
-      _.rootScope.apply();
+      _.rootScope.flush();
 
       expect(_.rootScope.context['p'].injector.get(RouteProvider) is NgView).toBeTruthy();
     }));
@@ -56,29 +59,31 @@ main() {
 
     it('should switch template when route is already active', async(() {
       // Force the routing system to initialize.
-      _.compile('<ng-view></ng-view>');
+      _.compile('<div><ng-view></ng-view></div>');
 
       router.route('/foo');
       microLeap();
-      Element root = _.compile('<ng-view></ng-view>');
+      Element root = _.compile('<div><ng-view></ng-view></div>');
       expect(root.text).toEqual('');
 
-      _.rootScope.apply();
       microLeap();
+      _.rootScope.flush();
       expect(root.text).toEqual('Foo');
     }));
 
 
     it('should clear template when route is deactivated', async(() {
-      Element root = _.compile('<ng-view></ng-view>');
+      Element root = _.compile('<div><ng-view></ng-view></div>');
       expect(root.text).toEqual('');
 
       router.route('/foo');
       microLeap();
+      _.rootScope.flush();
       expect(root.text).toEqual('Foo');
 
       router.route('/baz'); // route without a template
       microLeap();
+      _.rootScope.flush();
       expect(root.text).toEqual('');
     }));
 
@@ -111,25 +116,29 @@ main() {
     });
 
     it('should switch nested templates', async(() {
-      Element root = _.compile('<ng-view></ng-view>');
+      Element root = _.compile('<div><ng-view></ng-view></div>');
       expect(root.text).toEqual('');
 
       router.route('/library/all');
       microLeap();
+      _.rootScope.flush();
       expect(root.text).toEqual('LibraryBooks');
 
       router.route('/library/1234');
       microLeap();
+      _.rootScope.flush();
       expect(root.text).toEqual('LibraryBook 1234');
 
       // nothing should change here
       router.route('/library/1234/overview');
       microLeap();
+      _.rootScope.flush();
       expect(root.text).toEqual('LibraryBook 1234');
 
       // nothing should change here
       router.route('/library/1234/read');
       microLeap();
+      _.rootScope.flush();
       expect(root.text).toEqual('LibraryRead Book 1234');
     }));
   });
@@ -157,11 +166,12 @@ main() {
     });
 
     it('should switch inline templates', async(() {
-      Element root = _.compile('<ng-view></ng-view>');
+      Element root = _.compile('<div><ng-view></ng-view></div>');
       expect(root.text).toEqual('');
 
       router.route('/foo');
       microLeap();
+      _.rootScope.flush();
       expect(root.text).toEqual('Hello');
     }));
   });

--- a/test/routing/routing_spec.dart
+++ b/test/routing/routing_spec.dart
@@ -158,11 +158,12 @@ main() {
       _.injector.get(TemplateCache)
           .put('foo.html', new HttpResponse(200, '<h1>Foo</h1>'));
 
-      Element root = _.compile('<ng-view></ng-view>');
+      Element root = _.compile('<div><ng-view></ng-view></div>');
       expect(root.text).toEqual('');
 
       router.route('/foo');
       microLeap();
+      _.rootScope.flush();
 
       expect(enterCount).toBe(1);
       expect(root.text).toEqual('Foo');
@@ -231,17 +232,19 @@ main() {
       _.injector.get(TemplateCache)
           .put('foo.html', new HttpResponse(200, '<h1>Foo</h1>'));
 
-      Element root = _.compile('<ng-view></ng-view>');
+      Element root = _.compile('<div><ng-view></ng-view></div>');
       expect(root.text).toEqual('');
 
       router.route('/foo');
       microLeap();
+      _.rootScope.flush();
 
       expect(root.text).toEqual('Foo');
       expect(leaveCount).toBe(0);
 
       router.route('/bar');
       microLeap();
+      _.rootScope.flush();
 
       expect(root.text).toEqual('');
       expect(leaveCount).toBe(1);
@@ -263,11 +266,12 @@ main() {
       _.injector.get(TemplateCache)
           .put('foo.html', new HttpResponse(200, '<div make-it-new>Old!</div>'));
 
-      Element root = _.compile('<ng-view></ng-view>');
+      Element root = _.compile('<div><ng-view></ng-view></div>');
       expect(root.text).toEqual('');
 
       router.route('/foo');
       microLeap();
+      _.rootScope.flush();
 
       expect(root.text).toEqual('New!');
     }));
@@ -288,11 +292,12 @@ main() {
       _.injector.get(TemplateCache)
           .put('foo.html', new HttpResponse(200, '<div make-it-new>Old!</div>'));
 
-      Element root = _.compile('<ng-view></ng-view>');
+      Element root = _.compile('<div><ng-view></ng-view></div>');
       expect(root.text).toEqual('');
 
       router.route('/foo');
       microLeap();
+      _.rootScope.flush();
 
       expect(root.text).toEqual('New!');
     }));
@@ -313,7 +318,7 @@ main() {
       _.injector.get(TemplateCache)
           .put('foo.html', new HttpResponse(200, '<div>{{\'World\' | hello}}</div>'));
 
-      Element root = _.compile('<ng-view></ng-view>');
+      Element root = _.compile('<div><ng-view></ng-view></div>');
       expect(root.text).toEqual('');
 
       router.route('/foo');
@@ -339,7 +344,7 @@ main() {
       _.injector.get(TemplateCache)
           .put('foo.html', new HttpResponse(200, '<div>{{\'World\' | hello}}</div>'));
 
-      Element root = _.compile('<ng-view></ng-view>');
+      Element root = _.compile('<div><ng-view></ng-view></div>');
       expect(root.text).toEqual('');
 
       router.route('/foo');


### PR DESCRIPTION
# Closes 704

This was first introduced by #910 and later reverted in #991.

Some info about the change:
- `NgView` now makes use of the `ViewPort` instead of appending / removing elements manually,
- This means that `<ng-view>` is removed from the DOM in favor of an anchor (HTML comment),
- To exist the anchor must have a parent, which is which `<ng-view>`s are wrapped in `div` in the tests,
- The added `_.rootScope.apply()` is required to run the flush phase when the view are inserto to /removed from the DOM.

@pavelgj @jbdeboer you have both commented the original PR, could you please review this one and let me know if you seen issues with it. Thanks.
