### PR TITLE
feat(ng-base-css): useNgBaseCss Component annotation field.

### DIFF
--- a/lib/core/annotation_src.dart
+++ b/lib/core/annotation_src.dart
@@ -316,6 +316,11 @@ class Component extends Directive {
    */
   final bool useShadowDom;
 
+  /**
+   * Defaults to true, but if set to false any NgBaseCss stylesheets will be ignored.
+   */
+  final bool useNgBaseCss;
+
   const Component({
     this.template,
     this.templateUrl,
@@ -329,7 +334,8 @@ class Component extends Directive {
     visibility,
     exportExpressions,
     exportExpressionAttrs,
-    this.useShadowDom})
+    this.useShadowDom,
+    this.useNgBaseCss: true})
       : _cssUrls = cssUrl,
         _applyAuthorStyles = applyAuthorStyles,
         _resetStyleInheritance = resetStyleInheritance,
@@ -359,7 +365,8 @@ class Component extends Directive {
           visibility: visibility,
           exportExpressions: exportExpressions,
           exportExpressionAttrs: exportExpressionAttrs,
-          useShadowDom: useShadowDom);
+          useShadowDom: useShadowDom,
+          useNgBaseCss: useNgBaseCss);
 }
 
 /**

--- a/lib/core_dom/shadow_dom_component_factory.dart
+++ b/lib/core_dom/shadow_dom_component_factory.dart
@@ -41,7 +41,7 @@ class ShadowDomComponentFactory implements ComponentFactory {
         Http http = injector.get(Http);
         TemplateCache templateCache = injector.get(TemplateCache);
         DirectiveMap directives = injector.get(DirectiveMap);
-        NgBaseCss baseCss = injector.get(NgBaseCss);
+        NgBaseCss baseCss = component.useNgBaseCss ? injector.get(NgBaseCss) : null;
         // This is a bit of a hack since we are returning different type then we are.
         var componentFactory = new _ComponentFactory(node,
             ref.type,
@@ -103,7 +103,9 @@ class _ComponentFactory implements Function {
     // so change back to using @import once Chrome bug is fixed or a
     // better work around is found.
     Iterable<async.Future<dom.StyleElement>> cssFutures;
-    var cssUrls = []..addAll(_baseCss.urls)..addAll(component.cssUrls);
+    var cssUrls = _baseCss != null ?
+      ([]..addAll(_baseCss.urls)..addAll(component.cssUrls)) :
+      component.cssUrls;
     var tag = element.tagName.toLowerCase();
     if (cssUrls.isNotEmpty) {
       cssFutures = cssUrls.map((cssUrl) => _styleElementCache.putIfAbsent(


### PR DESCRIPTION
Introduces a useNgBaseCss field in the `@Component` annotation.

It defaults to true, but when set to false, the component will not
load any base CSS files.  For components that do not rely on base
CSS, loading a global CSS file can be a significant performance issue.

Best practices say that large global CSS files are an anti-pattern for
shadow DOM based apps.  ng-base-css allows apps to use this anti-pattern
to support legacy app design.

The useNgBaseCss field allows app developers to transition to
per-component styles and reap the performance benefits immediately.
