### PR TITLE
chore(docs): Fix left nav menu and restore di to nav

### DIFF
--- a/lib/di/module.dart
+++ b/lib/di/module.dart
@@ -1,0 +1,3 @@
+library di;
+
+export 'package:di/di.dart' hide lastKeyId;

--- a/scripts/generate-documentation.sh
+++ b/scripts/generate-documentation.sh
@@ -17,8 +17,8 @@ cat README-orig.md | sed "1s/^AngularDart.*/AngularDart/" > README.md
     --start-page=angular \
     --exclude-lib=js,metadata,meta,mirrors,intl,number_symbols,number_symbol_data,intl_helpers,date_format_internal,date_symbols,angular.util \
     --no-include-sdk \
+    --include-dependent-packages \
     --package-root=packages \
-    lib/angular.dart \
     lib/application_factory.dart \
     lib/application_factory_static.dart \
     lib/application.dart lib/introspection.dart \
@@ -30,6 +30,7 @@ cat README-orig.md | sed "1s/^AngularDart.*/AngularDart/" > README.md
     lib/routing/module.dart \
     lib/mock/module.dart \
     lib/perf/module.dart \
+    lib/di/module.dart
 )
 
 # Revert the temp copy of the README.md file


### PR DESCRIPTION
I'm trying to figure out how to get di.dart back in the left nav. I thought --include-dependent-packages would have done that, but it doesn't seem to work unless I explicitly create a module under lib/ that has the export 'package:di/di.dart' statement in it.  This PR also drops the top-level "angular" from the left-nav to eliminate duplication in the docs.
