### PR TITLE
fix(dccd): fix removals reporting

### DIFF
--- a/lib/change_detection/dirty_checking_change_detector.dart
+++ b/lib/change_detection/dirty_checking_change_detector.dart
@@ -1140,9 +1140,6 @@ class _CollectionChangeRecord<V> implements CollectionChangeRecord<V> {
     var prev = record._prevRemoved;
     var next = record._nextRemoved;
 
-    assert((record._prevRemoved = null) == null);
-    assert((record._nextRemoved = null) == null);
-
     if (prev == null) {
       _removalsHead = next;
     } else {
@@ -1247,10 +1244,12 @@ class _CollectionChangeRecord<V> implements CollectionChangeRecord<V> {
   ItemRecord<V> _addToRemovals(ItemRecord<V> record) {
     _removedItems.put(record);
     record.currentIndex = null;
+    record._nextRemoved = null;
 
     if (_removalsTail == null) {
       assert(_removalsHead == null);
       _removalsTail = _removalsHead = record;
+      record._prevRemoved = null;
     } else {
       assert(_removalsTail._nextRemoved == null);
       assert(record._nextRemoved == null);

--- a/test/change_detection/dirty_checking_change_detector_spec.dart
+++ b/test/change_detection/dirty_checking_change_detector_spec.dart
@@ -288,6 +288,31 @@ void testWithGetterFactory(FieldGetterFactory getterFactory) {
               moves: ['2[1 -> 0]', '1[0 -> 1]'],
               removals: []));
         });
+
+        it('should handle swapping elements correctly - gh1097', () {
+          // This test would only have failed in non-checked mode only
+          var list = ['a', 'b', 'c'];
+          var record = detector.watch(list, null, null);
+          var iterator = detector.collectChanges()..moveNext();
+
+          list..clear()..addAll(['b', 'a', 'c']);
+          iterator = detector.collectChanges()..moveNext();
+          expect(iterator.current.currentValue, toEqualCollectionRecord(
+              collection: ['b[1 -> 0]', 'a[0 -> 1]', 'c'],
+              previous: ['a[0 -> 1]', 'b[1 -> 0]', 'c'],
+              additions: [],
+              moves: ['b[1 -> 0]', 'a[0 -> 1]', 'c'],
+              removals: []));
+
+          list..clear()..addAll(['b', 'c', 'a']);
+          iterator = detector.collectChanges()..moveNext();
+          expect(iterator.current.currentValue, toEqualCollectionRecord(
+              collection: ['b', 'c[2 -> 1]', 'a[1 -> 2]'],
+              previous: ['b', 'a[1 -> 2]', 'c[2 -> 1]'],
+              additions: [],
+              moves: ['c[2 -> 1]', 'a[1 -> 2]'],
+              removals: []));
+        });
       });
 
       it('should detect changes in list', () {


### PR DESCRIPTION
@jbdeboer / someone could you please review this, I'd like to merge it today.

The problem was that we keep a linked list of removed element but the the next and previous links were never resetted.

Then it could happen that we get a wrong value in `_reinsertAfter` (ie a value from a previous `_check`).

It used to work in checked mode where the links were resetted in `assert()`s
