### PR TITLE
refactor(dccd): Drop the insertBefore arg from DuplicateMap.put()

### DIFF
--- a/lib/change_detection/dirty_checking_change_detector.dart
+++ b/lib/change_detection/dirty_checking_change_detector.dart
@@ -1320,39 +1320,21 @@ class _DuplicateItemRecordList {
   ItemRecord _head, _tail;
 
   /**
-   * Add the [record] before the [insertBefore] in the list of duplicates or at the end of the list
-   * when no [insertBefore] is specified.
+   * Append the [record] to the list of duplicates.
    *
    * Note: by design all records in the list of duplicates hold the save value in [record.item].
    */
-  void add(ItemRecord record, ItemRecord insertBefore) {
-    assert(insertBefore == null || insertBefore.item == record.item);
+  void add(ItemRecord record) {
     if (_head == null) {
-      /// pushing the first [ItemRecord] to the list
-      assert(insertBefore == null);
       _head = _tail = record;
       record._nextDup = null;
       record._prevDup = null;
     } else {
-      // adding a duplicate [ItemRecord] to the list
       assert(record.item == _head.item);
-      if (insertBefore == null) {
-        _tail._nextDup = record;
-        record._prevDup = _tail;
-        record._nextDup = null;
-        _tail = record;
-      } else {
-        var prev = insertBefore._prevDup;
-        var next = insertBefore;
-        record._prevDup = prev;
-        record._nextDup = next;
-        if (prev == null) {
-          _head = record;
-        } else {
-          prev._nextDup = record;
-        }
-        next._prevDup = record;
-      }
+      _tail._nextDup = record;
+      record._prevDup = _tail;
+      record._nextDup = null;
+      _tail = record;
     }
   }
 
@@ -1408,8 +1390,8 @@ class _DuplicateItemRecordList {
 class DuplicateMap {
   final map = <dynamic, _DuplicateItemRecordList>{};
 
-  void put(ItemRecord record, [ItemRecord insertBefore = null]) {
-    map.putIfAbsent(record.item, () => new _DuplicateItemRecordList()).add(record, insertBefore);
+  void put(ItemRecord record) {
+    map.putIfAbsent(record.item, () => new _DuplicateItemRecordList()).add(record);
   }
 
   /**


### PR DESCRIPTION
Closes #1128

The insertBefore argument is never used in the current code
