### PR TITLE
chore(transformers): use dartSdkDirectory from code_transformers

### DIFF
--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -48,10 +48,7 @@ TransformOptions _parseSettings(Map args) {
   injectedTypes.addAll(_readStringListValue(args, 'injected_types'));
 
   var sdkDir = _readStringValue(args, 'dart_sdk', required: false);
-  if (sdkDir == null) {
-    // Assume the Pub executable is always coming from the SDK.
-    sdkDir =  path.dirname(path.dirname(Platform.executable));
-  }
+  if (sdkDir == null) sdkDir = dartSdkDirectory;
 
   var diOptions = new di.TransformOptions(
       injectableAnnotations: annotations,


### PR DESCRIPTION
package:code_transformers provides a standard, relatively comprehensive lookup for the SDK directory.
