### PR TITLE
feat(directives): add support for multiple selectors separated by commas

### DIFF
--- a/lib/directive/ng_cloak.dart
+++ b/lib/directive/ng_cloak.dart
@@ -30,8 +30,7 @@ part of angular.directive;
  *      <div class="myclass ng-cloak">
  *
  */
-@Decorator(selector: '[ng-cloak]')
-@Decorator(selector: '.ng-cloak')
+@Decorator(selector: '[ng-cloak], .ng-cloak')
 class NgCloak {
   NgCloak(dom.Element element, Animate animate) {
     element.attributes.remove('ng-cloak');

--- a/lib/directive/ng_form.dart
+++ b/lib/directive/ng_form.dart
@@ -6,13 +6,7 @@ part of angular.directive;
  * or prevent the default browser submission from occurring.
  */
 @Decorator(
-    selector: 'form',
-    module: NgForm.module)
-@Decorator(
-    selector: 'fieldset',
-    module: NgForm.module)
-@Decorator(
-    selector: '.ng-form',
+    selector: 'form, fieldset, .nf-form',
     module: NgForm.module)
 @Decorator(
     selector: '[ng-form]',

--- a/lib/directive/ng_model.dart
+++ b/lib/directive/ng_model.dart
@@ -338,13 +338,14 @@ class InputCheckbox {
  * the value of the input element is updated.
  *
  */
-@Decorator(selector: 'textarea[ng-model]')
-@Decorator(selector: 'input[type=text][ng-model]')
-@Decorator(selector: 'input[type=password][ng-model]')
-@Decorator(selector: 'input[type=url][ng-model]')
-@Decorator(selector: 'input[type=email][ng-model]')
-@Decorator(selector: 'input[type=search][ng-model]')
-@Decorator(selector: 'input[type=tel][ng-model]')
+@Decorator(selector: '''
+    textarea[ng-model],
+    input[type=text][ng-model],
+    input[type=password][ng-model],
+    input[type=url][ng-model],
+    input[type=email][ng-model],
+    input[type=search][ng-model],
+    input[type=tel][ng-model]''')
 class InputTextLike {
   final dom.Element inputElement;
   final NgModel ngModel;
@@ -409,8 +410,7 @@ class InputTextLike {
  * Setting the model to `double.NAN` will have no effect (input will be left
  * unchanged).
  */
-@Decorator(selector: 'input[type=number][ng-model]')
-@Decorator(selector: 'input[type=range][ng-model]')
+@Decorator(selector: 'input[type=number][ng-model], input[type=range][ng-model]')
 class InputNumberLike {
   final dom.InputElement inputElement;
   final NgModel ngModel;
@@ -474,12 +474,13 @@ class InputNumberLike {
  * kind would be appropriate) or, for browsers that fail to conform to the
  * HTML5 standard in their processing of date-like inputs.
  */
-@Decorator(selector: 'input[type=date][ng-model][ng-bind-type]')
-@Decorator(selector: 'input[type=time][ng-model][ng-bind-type]')
-@Decorator(selector: 'input[type=datetime][ng-model][ng-bind-type]')
-@Decorator(selector: 'input[type=datetime-local][ng-model][ng-bind-type]')
-@Decorator(selector: 'input[type=month][ng-model][ng-bind-type]')
-@Decorator(selector: 'input[type=week][ng-model][ng-bind-type]')
+@Decorator(selector: '''
+    input[type=date][ng-model][ng-bind-type],
+    input[type=time][ng-model][ng-bind-type],
+    input[type=datetime][ng-model][ng-bind-type],
+    input[type=datetime-local][ng-model][ng-bind-type],
+    input[type=month][ng-model][ng-bind-type],
+    input[type=week][ng-model][ng-bind-type]''')
 class NgBindTypeForDateLike {
   static const DATE = 'date';
   static const NUMBER = 'number';
@@ -586,17 +587,13 @@ class NgBindTypeForDateLike {
  *   dropped.
  */
 
-@Decorator(selector: 'input[type=date][ng-model]',
-    module: InputDateLike.moduleFactory)
-@Decorator(selector: 'input[type=time][ng-model]',
-    module: InputDateLike.moduleFactory)
-@Decorator(selector: 'input[type=datetime][ng-model]',
-    module: InputDateLike.moduleFactory)
-@Decorator(selector: 'input[type=datetime-local][ng-model]',
-    module: InputDateLike.moduleFactory)
-@Decorator(selector: 'input[type=month][ng-model]',
-    module: InputDateLike.moduleFactory)
-@Decorator(selector: 'input[type=week][ng-model]',
+@Decorator(selector: '''
+    input[type=date][ng-model],
+    input[type=time][ng-model],
+    input[type=datetime][ng-model],
+    input[type=datetime-local][ng-model],
+    input[type=month][ng-model],
+    input[type=week][ng-model]''',
     module: InputDateLike.moduleFactory)
 class InputDateLike {
   static Module moduleFactory() => new Module()..bind(NgBindTypeForDateLike,
@@ -691,8 +688,7 @@ final _uidCounter = new _UidCounter();
  * the `ng-model` property when the corresponding radio element or option is
  * selected.
  */
-@Decorator(selector: 'input[type=radio][ng-model][ng-value]')
-@Decorator(selector: 'option[ng-value]')
+@Decorator(selector: 'input[type=radio][ng-model][ng-value], option[ng-value]')
 class NgValue {
   static Module _module = new Module()..bind(NgValue);
   static Module moduleFactory() => _module;

--- a/lib/directive/ng_model_validators.dart
+++ b/lib/directive/ng_model_validators.dart
@@ -89,8 +89,7 @@ class NgModelEmailValidator implements NgValidator {
 /**
  * Validates the model to see if its contents match a valid number.
  */
-@Decorator(selector: 'input[type=number][ng-model]')
-@Decorator(selector: 'input[type=range][ng-model]')
+@Decorator(selector: 'input[type=number][ng-model], input[type=range][ng-model]')
 class NgModelNumberValidator implements NgValidator {
 
   final String name = 'ng-number';
@@ -117,13 +116,9 @@ class NgModelNumberValidator implements NgValidator {
 /**
  * Validates the model to see if the numeric value than or equal to the max value.
  */
-@Decorator(selector: 'input[type=number][ng-model][max]')
-@Decorator(selector: 'input[type=range][ng-model][max]')
+@Decorator(selector: 'input[type=number][ng-model][max], input[type=range][ng-model][max]')
 @Decorator(
-    selector: 'input[type=number][ng-model][ng-max]',
-    map: const {'ng-max': '=>max'})
-@Decorator(
-    selector: 'input[type=range][ng-model][ng-max]',
+    selector: 'input[type=number][ng-model][ng-max], input[type=range][ng-model][ng-max]',
     map: const {'ng-max': '=>max'})
 class NgModelMaxNumberValidator implements NgValidator {
 
@@ -168,13 +163,9 @@ class NgModelMaxNumberValidator implements NgValidator {
 /**
  * Validates the model to see if the numeric value is greater than or equal to the min value.
  */
-@Decorator(selector: 'input[type=number][ng-model][min]')
-@Decorator(selector: 'input[type=range][ng-model][min]')
+@Decorator(selector: 'input[type=number][ng-model][min], input[type=range][ng-model][min]')
 @Decorator(
-    selector: 'input[type=number][ng-model][ng-min]',
-    map: const {'ng-min': '=>min'})
-@Decorator(
-    selector: 'input[type=range][ng-model][ng-min]',
+    selector: 'input[type=number][ng-model][ng-min], input[type=range][ng-model][ng-min]',
     map: const {'ng-min': '=>min'})
 class NgModelMinNumberValidator implements NgValidator {
 

--- a/lib/directive/ng_pluralize.dart
+++ b/lib/directive/ng_pluralize.dart
@@ -83,10 +83,7 @@ part of angular.directive;
  * must also provide plural strings for at least the "other" plural category.
  */
 @Decorator(
-    selector: 'ng-pluralize',
-    map: const { 'count': '=>count' })
-@Decorator(
-    selector: '[ng-pluralize]',
+    selector: 'ng-pluralize, [ng-pluralize]',
     map: const { 'count': '=>count' })
 class NgPluralize {
   final dom.Element _element;

--- a/lib/tools/selector.dart
+++ b/lib/tools/selector.dart
@@ -37,81 +37,128 @@ class _SelectorPart {
       : element;
 }
 
-List<_SelectorPart> _splitCss(String selector) {
-  List<_SelectorPart> parts = [];
-  var remainder = selector;
-  var match;
-  while (!remainder.isEmpty) {
-    if ((match = _SELECTOR_REGEXP.firstMatch(remainder)) != null) {
-      if (match[1] != null) {
-        parts.add(new _SelectorPart.fromElement(match[1].toLowerCase()));
-      } else if (match[2] != null) {
-        parts.add(new _SelectorPart.fromClass(match[2].toLowerCase()));
-      } else if (match[3] != null) {
-        var attrValue = match[4] == null ? '' : match[4].toLowerCase();
-        parts.add(new _SelectorPart.fromAttribute(match[3].toLowerCase(),
-                                                  attrValue));
-      } else {
-        throw "Missmatched RegExp $_SELECTOR_REGEXP on $remainder";
-      }
-    } else {
-      throw "Unknown selector format '$remainder'.";
-    }
-    remainder = remainder.substring(match.end);
-  }
-  return parts;
-}
+bool matchesNode(Node node, String compositeSelector) {
+  final parser = new CssSelectorParser();
 
-bool matchesNode(Node node, String selector) {
-  var match, selectorParts;
-  if ((match = _CONTAINS_REGEXP.firstMatch(selector)) != null) {
-    if (node is! Text) {
+  return parser.splitCompositeSelector(compositeSelector).any((selector) {
+    var match, selectorParts;
+    if ((match = _CONTAINS_REGEXP.firstMatch(selector)) != null) {
+      if (node is! Text) {
+        return false;
+      }
+      return new RegExp(match.group(1)).hasMatch((node as Text).text);
+    } else if ((match = _ATTR_CONTAINS_REGEXP.firstMatch(selector)) != null) {
+      if (node is! Element) {
+        return false;
+      }
+      var regexp = new RegExp(match.group(1));
+      for (String attrName in node.attributes.keys) {
+        if (regexp.hasMatch(node.attributes[attrName])) {
+          return true;
+        }
+      }
       return false;
-    }
-    return new RegExp(match.group(1)).hasMatch((node as Text).text);
-  } else if ((match = _ATTR_CONTAINS_REGEXP.firstMatch(selector)) != null) {
-    if (node is! Element) {
-      return false;
-    }
-    var regexp = new RegExp(match.group(1));
-    for (String attrName in node.attributes.keys) {
-      if (regexp.hasMatch(node.attributes[attrName])) {
-        return true;
-      }
-    }
-    return false;
-  } else if ((selectorParts = _splitCss(selector)) != null) {
-    if (node is! Element) return false;
-    String nodeName = (node as Element).localName.toLowerCase();
+    } else if ((selectorParts = parser.splitSelectorIntoParts(selector)) != null) {
+      if (node is! Element) return false;
+      String nodeName = (node as Element).localName.toLowerCase();
 
-    bool stillGood = true;
-    selectorParts.forEach((_SelectorPart part) {
-      if (part.element != null) {
-        if (nodeName != part.element) {
-          stillGood = false;
+      bool stillGood = true;
+      selectorParts.forEach((_SelectorPart part) {
+        if (part.element != null) {
+          if (nodeName != part.element) {
+            stillGood = false;
+          }
+        } else if (part.className != null) {
+          if (node.attributes['class'] == null ||
+          !node.attributes['class'].split(' ').contains(part.className)) {
+            stillGood = false;
+          }
+        } else if (part.attrName != null) {
+          String matchingKey = _matchingKey(node.attributes.keys, part.attrName);
+          if (matchingKey == null || part.attrValue == '' ?
+          node.attributes[matchingKey] == null :
+          node.attributes[matchingKey] != part.attrValue) {
+            stillGood = false;
+          }
         }
-      } else if (part.className != null) {
-        if (node.attributes['class'] == null ||
-            !node.attributes['class'].split(' ').contains(part.className)) {
-          stillGood = false;
-        }
-      } else if (part.attrName != null) {
-        String matchingKey = _matchingKey(node.attributes.keys, part.attrName);
-        if (matchingKey == null || part.attrValue == '' ?
-              node.attributes[matchingKey] == null :
-              node.attributes[matchingKey] != part.attrValue) {
-          stillGood = false;
-        }
-      }
-    });
+      });
 
-    return stillGood;
-  }
+      return stillGood;
+    }
 
-  throw new ArgumentError('Unsupported Selector: $selector');
+    throw new ArgumentError('Unsupported Selector: $selector');
+  });
 }
 
 String _matchingKey(Iterable keys, String attrName) =>
     keys.firstWhere(
         (key) => new RegExp('^${attrName.replaceAll('*', r'[\w\-]+')}\$').hasMatch(key.toString()),
         orElse: () => null);
+
+class CssSelectorParser {
+  /**
+   * Turn a composite CSS selector string into a list of simple selectors
+   */
+  List<String> splitCompositeSelector(String selector) {
+    final res = [];
+    final buffer = new StringBuffer();
+    final stack = [];
+
+    addSelectorToResults() => res.add(buffer.toString().trim());
+
+    isQuote(String c) => c == '/' || c == '"' || c == "'" ;
+
+    handleQuote(String c) {
+      if (!isQuote(c)) return;
+
+      if (stack.isNotEmpty && stack.last == c) {
+        stack.removeLast();
+      } else {
+        stack.add(c);
+      }
+    }
+
+    for (var i = 0; i < selector.length; ++i) {
+      var c = selector[i];
+      if (c == ',' && stack.isEmpty) {
+        addSelectorToResults();
+        buffer.clear();
+      } else {
+        handleQuote(c);
+        buffer.write(c);
+      }
+    }
+
+    addSelectorToResults();
+
+    return res;
+  }
+
+  /**
+   * Turn a CSS selector string into a list of [_SelectorPart]s
+   */
+  List<_SelectorPart> splitSelectorIntoParts(String selector) {
+    var parts = <_SelectorPart>[];
+    var remainder = selector;
+    var match;
+    while (remainder.isNotEmpty) {
+      if ((match = _SELECTOR_REGEXP.firstMatch(remainder)) != null) {
+        if (match[1] != null) {
+          parts.add(new _SelectorPart.fromElement(match[1].toLowerCase()));
+        } else if (match[2] != null) {
+          parts.add(new _SelectorPart.fromClass(match[2].toLowerCase()));
+        } else if (match[3] != null) {
+          var attrValue = match[4] == null ? '' : match[4].toLowerCase();
+          parts.add(new _SelectorPart.fromAttribute(match[3].toLowerCase(),
+          attrValue));
+        } else {
+          throw "Missmatched RegExp $_SELECTOR_REGEXP on $remainder";
+        }
+      } else {
+        throw "Unknown selector format '$selector'";
+      }
+      remainder = remainder.substring(match.end);
+    }
+    return parts;
+  }
+}

--- a/test/tools/selector_spec.dart
+++ b/test/tools/selector_spec.dart
@@ -52,6 +52,15 @@ void main() {
       expect(matchesNode(node, 'b[directive=wrongvalue]'), isFalse);
     });
 
+    it('should match directive when multiple selectors separated by a comma', () {
+      final nodeA = new Element.html('<div directiveA></div>');
+      expect(matchesNode(nodeA, '[directiveA],[directiveB]'), isTrue);
+      expect(matchesNode(nodeA, '[directiff]'), isFalse);
+
+      final nodeB = new Element.html('<div directiveB></div>');
+      expect(matchesNode(nodeB, '[directiveA],[directiveB]'), isTrue);
+    });
+
     it('should match attributes', () {
       var node = new Element.html('<div attr="before-xyz-after"></div>');
       expect(matchesNode(node, '[*=/xyz/]'), isTrue);


### PR DESCRIPTION
Add support for multiple selectors when defining a directive. Selectors should be separated by commas.

Closes #304
