### PR TITLE
feat(WatchGroup): Allow measuring cost of running reaction functions and

### DIFF
--- a/benchmark/watch_group_perf.dart
+++ b/benchmark/watch_group_perf.dart
@@ -51,7 +51,7 @@ class _CollectionCheck extends BenchmarkBase {
 
 _fieldRead() {
   var watchGrp = new RootWatchGroup(_dynamicFieldGetterFactory,
-      new DirtyCheckingChangeDetector(_dynamicFieldGetterFactory), new _Obj())
+      new DirtyCheckingChangeDetector(_dynamicFieldGetterFactory), new _Obj(), null)
           ..watch(_parse('a'), _reactionFn)
           ..watch(_parse('b'), _reactionFn)
           ..watch(_parse('c'), _reactionFn)
@@ -80,7 +80,7 @@ _fieldRead() {
 
 _fieldReadGetter() {
   var  watchGrp= new RootWatchGroup(_staticFieldGetterFactory,
-      new DirtyCheckingChangeDetector(_staticFieldGetterFactory), new _Obj())
+      new DirtyCheckingChangeDetector(_staticFieldGetterFactory), new _Obj(), null)
           ..watch(_parse('a'), _reactionFn)
           ..watch(_parse('b'), _reactionFn)
           ..watch(_parse('c'), _reactionFn)
@@ -114,7 +114,7 @@ _mapRead() {
       'k': 0, 'l': 1, 'm': 2, 'n': 3, 'o': 4,
       'p': 0, 'q': 1, 'r': 2, 's': 3, 't': 4};
   var watchGrp = new RootWatchGroup(_dynamicFieldGetterFactory,
-      new DirtyCheckingChangeDetector(_dynamicFieldGetterFactory), map)
+      new DirtyCheckingChangeDetector(_dynamicFieldGetterFactory), map, null)
           ..watch(_parse('a'), _reactionFn)
           ..watch(_parse('b'), _reactionFn)
           ..watch(_parse('c'), _reactionFn)
@@ -144,7 +144,7 @@ _methodInvoke0() {
   var context = new _Obj();
   context.a = new _Obj();
   var watchGrp = new RootWatchGroup(_dynamicFieldGetterFactory,
-      new DirtyCheckingChangeDetector(_dynamicFieldGetterFactory), context)
+      new DirtyCheckingChangeDetector(_dynamicFieldGetterFactory), context, null)
           ..watch(_method('a', 'methodA'), _reactionFn)
           ..watch(_method('a', 'methodB'), _reactionFn)
           ..watch(_method('a', 'methodC'), _reactionFn)
@@ -174,7 +174,7 @@ _methodInvoke1() {
   var context = new _Obj();
   context.a = new _Obj();
   var watchGrp = new RootWatchGroup(_dynamicFieldGetterFactory,
-      new DirtyCheckingChangeDetector(_dynamicFieldGetterFactory), context)
+      new DirtyCheckingChangeDetector(_dynamicFieldGetterFactory), context, null)
           ..watch(_method('a', 'methodA1', [_parse('a')]), _reactionFn)
           ..watch(_method('a', 'methodB1', [_parse('a')]), _reactionFn)
           ..watch(_method('a', 'methodC1', [_parse('a')]), _reactionFn)
@@ -203,7 +203,7 @@ _methodInvoke1() {
 _function2() {
   var context = new _Obj();
   var watchGrp = new RootWatchGroup(_dynamicFieldGetterFactory,
-      new DirtyCheckingChangeDetector(_dynamicFieldGetterFactory), context)
+      new DirtyCheckingChangeDetector(_dynamicFieldGetterFactory), context, null)
           ..watch(_add(0, _parse('a'), _parse('a')), _reactionFn)
           ..watch(_add(1, _parse('a'), _parse('a')), _reactionFn)
           ..watch(_add(2, _parse('a'), _parse('a')), _reactionFn)

--- a/example/web/todo.dart
+++ b/example/web/todo.dart
@@ -96,7 +96,9 @@ main() {
   print(window.location.search);
   var module = new Module()
       ..bind(Todo)
-      ..bind(PlaybackHttpBackendConfig);
+      ..bind(PlaybackHttpBackendConfig)
+      ..bind(ExecutionStats, toFactory: (i) => new ExecutionStats(15, i.get(ExecutionStatsEmitter)))
+      ..bind(ExecutionStatsEmitter);
 
   // If these is a query in the URL, use the server-backed
   // TodoController.  Otherwise, use the stored-data controller.

--- a/lib/application.dart
+++ b/lib/application.dart
@@ -162,8 +162,7 @@ abstract class Application {
   }
 
   Injector run() {
-    publishToJavaScript();
-    return zone.run(() {
+    var injector = zone.run(() {
       var rootElements = [element];
       Injector injector = createInjector();
       ExceptionHandler exceptionHandler = injector.getByKey(EXCEPTION_HANDLER_KEY);
@@ -178,6 +177,8 @@ abstract class Application {
       });
       return injector;
     });
+    publishToJavaScript(injector);
+    return injector;
   }
 
   /**

--- a/lib/change_detection/change_detection.dart
+++ b/lib/change_detection/change_detection.dart
@@ -1,5 +1,7 @@
 library change_detection;
 
+import 'package:angular/change_detection/execution_stats.dart';
+
 typedef void EvalExceptionHandler(error, stack);
 
 /**
@@ -54,6 +56,7 @@ abstract class ChangeDetector<H> extends ChangeDetectorGroup<H> {
    * same order as they were registered.
    */
   Iterator<Record<H>> collectChanges({EvalExceptionHandler exceptionHandler,
+                                      ExecutionStats executionStats, Stopwatch executionStopwatch,
                                       AvgStopwatch stopwatch });
 }
 

--- a/lib/change_detection/execution_stats.dart
+++ b/lib/change_detection/execution_stats.dart
@@ -1,0 +1,143 @@
+library angular.change_detection.execution_stats;
+
+import 'package:angular/core/annotation_src.dart';
+
+@Injectable()
+class ExecutionStats {
+  final ExecutionStatsConfig config;
+  final ExecutionStatsEmitter emitter;
+  List<ExecutionEntry> _dirtyCheckStats;
+  List<ExecutionEntry> _dirtyWatchStats;
+  List<ExecutionEntry> _evalStats;
+  int _evalsCount = 0;
+  int _dirtyWatchCount = 0;
+  int _dirtyCheckCount = 0;
+
+  int get _capacity => config.maxEntries;
+
+  ExecutionStats(this.emitter, this.config) {
+    reset();
+  }
+
+  void addDirtyCheckEntry(ExecutionEntry entry) {
+    if( ++_dirtyCheckCount >= _capacity) _shrinkDirtyCheck();
+    _dirtyCheckStats[_dirtyCheckCount] = entry;
+  }
+
+  void addDirtyWatchEntry(ExecutionEntry entry) {
+    if( ++_dirtyWatchCount >= _capacity) _shrinkDirtyWatch();
+    _dirtyWatchStats[_dirtyWatchCount] = entry;
+  }
+
+  void addEvalEntry(ExecutionEntry entry) {
+    if( ++_evalsCount >= _capacity) _shrinkEval();
+    _evalStats[_evalsCount] = entry;
+  }
+
+  void showEvalStats() {
+    emitter.showEvalStats(this);
+  }
+
+  void showReactionFnStats() {
+    emitter.showReactionFnStats(this);
+  }
+
+  void showDirtyCheckStats() {
+    emitter.showDirtyCheckStats(this);
+  }
+
+  Iterable<ExecutionEntry> get dirtyCheckStats {
+    _shrinkDirtyWatch();
+    return _dirtyCheckStats.getRange(0, _capacity).where((e) => e.time > 0);
+  }
+
+  Iterable<ExecutionEntry> get evalStats {
+    _shrinkDirtyWatch();
+    return _evalStats.getRange(0, _capacity).where((e) => e.time > 0);
+  }
+
+  Iterable<ExecutionEntry> get reactionFnStats {
+    _shrinkDirtyWatch();
+    return _dirtyWatchStats.getRange(0, _capacity).where((e) => e.time > 0);
+  }
+
+  void enable() {
+    config.enabled = true;
+  }
+
+  void disable() {
+    config.enabled = false;
+  }
+
+  void reset() {
+    _dirtyCheckStats = new List.filled(3 * _capacity, new ExecutionEntry(0, null));
+    _dirtyWatchStats = new List.filled(3 * _capacity, new ExecutionEntry(0, null));
+    _evalStats = new List.filled(3 * _capacity, new ExecutionEntry(0, null));
+    _evalsCount = 0;
+    _dirtyWatchCount = 0;
+    _dirtyCheckCount = 0;
+  }
+
+  void _shrinkDirtyCheck() {
+    _dirtyCheckStats.sort((ExecutionEntry x, ExecutionEntry y) => y.time.compareTo(x.time));
+    for(int i = _capacity; i < 3 * _capacity; i++) _dirtyCheckStats[i] = new ExecutionEntry(0, null);
+    _dirtyCheckCount = _capacity;
+  }
+
+  void _shrinkDirtyWatch() {
+    _dirtyWatchStats.sort((ExecutionEntry x, ExecutionEntry y) => x.time.compareTo(y.time) * -1);
+    for(int i = _capacity; i < 3 * _capacity; i++) _dirtyWatchStats[i] = new ExecutionEntry(0, null);
+    _dirtyWatchCount = _capacity;
+  }
+
+  void _shrinkEval() {
+    _evalStats.sort((ExecutionEntry x, ExecutionEntry y) => x.time.compareTo(y.time) * -1);
+    for(int i = _capacity; i < 3 * _capacity; i++) _evalStats[i] = new ExecutionEntry(0, null);
+    _evalsCount = _capacity;
+  }
+}
+
+@Injectable()
+class ExecutionStatsEmitter {
+  void showDirtyCheckStats(ExecutionStats fnStats) {
+    _printLine('Time (us)', 'Field');
+    fnStats.dirtyCheckStats.forEach((ExecutionEntry entry) =>
+    _printLine('${entry.time}', '${entry.value}'));
+  }
+
+  void showEvalStats(ExecutionStats fnStats) {
+    _printLine('Time (us)', 'Name');
+    fnStats.evalStats.forEach((ExecutionEntry entry) =>
+        _printLine('${entry.time}', '${entry.value}'));
+  }
+
+  void showReactionFnStats(ExecutionStats fnStats) {
+    _printLine('Time (us)', 'Expression');
+    fnStats.reactionFnStats.forEach((ExecutionEntry entry) =>
+        _printLine('${entry.time}', '${entry.value}'));
+  }
+
+  _printLine(String first, String second) {
+    var timesColLength = 10;
+    var expressionsColPrefix = 5;
+    var timesCol = ' ' * (timesColLength - first.length);
+    var expressionsCol = ' ' * expressionsColPrefix;
+    print('${timesCol + first}${expressionsCol + second}');
+  }
+
+}
+
+class ExecutionEntry {
+  final num time;
+  final dynamic value; //Record or Watch
+
+  ExecutionEntry(this.time, this.value);
+}
+
+class ExecutionStatsConfig {
+  bool enabled;
+  int threshold;
+  int maxEntries;
+
+  ExecutionStatsConfig({this.enabled: false, this.threshold, this.maxEntries: 15});
+}

--- a/lib/core/module.dart
+++ b/lib/core/module.dart
@@ -12,6 +12,9 @@ library angular.core;
 export "package:angular/change_detection/watch_group.dart" show
     ReactionFn;
 
+export 'package:angular/change_detection/execution_stats.dart' show
+    ExecutionStats, ExecutionStatsEmitter, ExecutionStatsConfig;
+
 export "package:angular/core/parser/parser.dart" show
     Parser;
 

--- a/lib/core/module_internal.dart
+++ b/lib/core/module_internal.dart
@@ -18,6 +18,8 @@ export 'package:angular/change_detection/watch_group.dart';
 import 'package:angular/change_detection/ast_parser.dart';
 import 'package:angular/change_detection/change_detection.dart';
 import 'package:angular/change_detection/dirty_checking_change_detector.dart';
+import 'package:angular/change_detection/execution_stats.dart';
+export 'package:angular/change_detection/execution_stats.dart';
 import 'package:angular/core/formatter.dart';
 export 'package:angular/core/formatter.dart';
 import 'package:angular/core/parser/utils.dart';
@@ -43,6 +45,7 @@ class CoreModule extends Module {
     bind(RootScope);
     bind(Scope, toFactory: (injector) => injector.getByKey(ROOT_SCOPE_KEY));
     bind(ClosureMap, toFactory: (_) => throw "Must provide dynamic/static ClosureMap.");
+    bind(ExecutionStats, toValue: null);
     bind(ScopeStats);
     bind(ScopeStatsEmitter);
     bind(ScopeStatsConfig, toFactory: (i) => new ScopeStatsConfig());

--- a/lib/core/scope.dart
+++ b/lib/core/scope.dart
@@ -315,8 +315,8 @@ class Scope {
     var child = new Scope(childContext, rootScope, this,
                           _readWriteGroup.newGroup(childContext),
                           _readOnlyGroup.newGroup(childContext),
-                         '$id:${_childScopeNextId++}',
-                         _stats);
+                          '$id:${_childScopeNextId++}',
+                          _stats);
 
     var prev = _childTail;
     child._prev = prev;
@@ -618,17 +618,17 @@ class RootScope extends Scope {
 
   RootScope(Object context, Parser parser, ASTParser astParser, FieldGetterFactory fieldGetterFactory,
             FormatterMap formatters, this._exceptionHandler, this._ttl, this._zone,
-            ScopeStats _scopeStats)
-      : _scopeStats = _scopeStats,
+            ScopeStats scopeStats, ExecutionStats execStats)
+      : _scopeStats = scopeStats,
         _parser = parser,
         _astParser = astParser,
         super(context, null, null,
             new RootWatchGroup(fieldGetterFactory,
-                new DirtyCheckingChangeDetector(fieldGetterFactory), context),
+                new DirtyCheckingChangeDetector(fieldGetterFactory), context, execStats),
             new RootWatchGroup(fieldGetterFactory,
-                new DirtyCheckingChangeDetector(fieldGetterFactory), context),
+                new DirtyCheckingChangeDetector(fieldGetterFactory), context, execStats),
             '',
-            _scopeStats)
+            scopeStats)
   {
     _zone.onTurnDone = apply;
     _zone.onError = (e, s, ls) => _exceptionHandler(e, s);

--- a/lib/introspection_js.dart
+++ b/lib/introspection_js.dart
@@ -16,7 +16,7 @@ import 'package:angular/core_dom/module_internal.dart';
  */
 var elementExpando = new Expando('element');
 
-void publishToJavaScript() {
+void publishToJavaScript(Injector rootInjector) {
   js.context
     ..['ngProbe'] = new js.JsFunction.withThis((_, nodeOrSelector) =>
         _jsProbe(ngProbe(nodeOrSelector)))
@@ -26,7 +26,8 @@ void publishToJavaScript() {
         _jsScope(ngScope(nodeOrSelector),
         ngProbe(nodeOrSelector).injector.getByKey(SCOPE_STATS_CONFIG_KEY)))
     ..['ngQuery'] = new js.JsFunction.withThis((_, dom.Node node, String selector,
-        [String containsText]) => new js.JsArray.from(ngQuery(node, selector, containsText)));
+        [String containsText]) => new js.JsArray.from(ngQuery(node, selector, containsText)))
+    ..['ngStats'] = new js.JsFunction.withThis((_) => _jsReactionFnStats(rootInjector.get(ExecutionStats)));
 }
 
 js.JsObject _jsProbe(ElementProbe probe) {
@@ -57,6 +58,17 @@ js.JsObject _jsScope(Scope scope, ScopeStatsConfig config) {
       "scopeStatsEnable": () => config.emit = true,
       "scopeStatsDisable": () => config.emit = false
   })..['_dart_'] = scope;
+}
+
+js.JsObject _jsReactionFnStats(ExecutionStats fnStats) {
+  return new js.JsObject.jsify({
+      "showDirtyCheckStats": fnStats.showDirtyCheckStats,
+      "showEvalStats": fnStats.showEvalStats,
+      "showReactionFnStats": fnStats.showReactionFnStats,
+      "enable": fnStats.enable,
+      "disable": fnStats.disable,
+      "reset": fnStats.reset,
+  })..['_dart_'] = fnStats;
 }
 
 _jsDirective(directive) => directive;

--- a/test/angular_spec.dart
+++ b/test/angular_spec.dart
@@ -94,6 +94,9 @@ main() {
       var ALLOWED_NAMES = [
         "angular.app.AngularModule",
         "angular.app.Application",
+        "angular.change_detection.execution_stats.ExecutionStats",
+        "angular.change_detection.execution_stats.ExecutionStatsConfig",
+        "angular.change_detection.execution_stats.ExecutionStatsEmitter",
         "angular.core.annotation.ShadowRootAware",
         "angular.core.annotation_src.AttachAware",
         "angular.core.annotation_src.Component",


### PR DESCRIPTION
```
To be able to measure cost of reaction function, dirty check and/or
dirty watch one needs to define ExecutionStats. ExecutionStats is
configured using ExecutionStatsConfig object. This object can be used to
define how many records to display when showing the stats, what's the
minimum threshold (in microseconds) for a record to be considered as
relevant as well as to enable and disable tracking the stats.

One can define ExecutionStats, ExectionStatsEmitter and
ExecutionStatsConfig like:

  m..bind(ExectionStats)
   ..bind(ExectionStatsEmitter)
   ..bind(ExectionStatsConfig, toFactory: (i) => new ExectionStats(...))

The results can be displayed using ngStats object. To obtain a reference
to an ngStats object type (in the console):

  ng = ngStats();

To display maxNumber (defined using ExectionStatsConfig object) of the
most expensive reaction functions type:

  ng.showReactionFnStats();

To display maxNumber of most expensive evals type:

  ng.showEvalStats();

To display maxNumber of most expensive dirty checks type:

  ng.showDirtyCheckStats();

One can use ng.enable() method to enable tracking and ng.disable()
method to disable trackin. To clear the results use ng.reset()
method.

To achieve least performance impact on the application make sure
that the ExectionStats is null.

  m..bind(ExectionStats, toValue: null);

That way no extra objects will be created and the impact on the
actual application will be minimal.
```
