### PR TITLE
test(annotion_src_spec): re-enable tests failing due to dartbug 19177

### DIFF
--- a/test/core/annotation_src_spec.dart
+++ b/test/core/annotation_src_spec.dart
@@ -30,9 +30,7 @@ List<String> nullFields(x) {
   return ret;
 }
 
-// TODO(deboer): These tests are disabled due to dartbug.com/19177
-// That bug should be fixed soon
-void main() => xdescribe('annotations', () {
+void main() => describe('annotations', () {
   describe('component', () {
     it('should set all fields on clone when all the fields are set', () {
       var component = new Component(


### PR DESCRIPTION
It has been fixed in 1.5.0-dev.4.5

/cc @jbdeboer
