### PR TITLE
chore(travis): fail build if a test has been 'iit'ed

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -36,7 +36,7 @@ packages:
   guinness:
     description: guinness
     source: hosted
-    version: "0.1.5"
+    version: "0.1.9"
   html5lib:
     description: html5lib
     source: hosted

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,4 +29,4 @@ dev_dependencies:
   benchmark_harness: '>=1.0.0'
   unittest: '>=0.10.1 <0.12.0'
   mock: '>=0.10.0 <0.12.0'
-  guinness: '>=0.1.3 <0.2.0'
+  guinness: '>=0.1.9 <0.2.0'

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -98,7 +98,18 @@ echo BROWSER=$BROWSERS
 $NGDART_BASE_DIR/node_modules/jasmine-node/bin/jasmine-node playback_middleware/spec/ &&
 node "node_modules/karma/bin/karma" start karma.conf \
     --reporters=junit,dots --port=8765 --runner-port=8766 \
-    --browsers=$BROWSERS --single-run --no-colors
+    --browsers=$BROWSERS --single-run --no-colors 2>&1 | tee karma-output.log
+
+if grep -q "WARN: iit" karma-output.log; then
+  echo "ERROR: iit caused some tests to be excluded"
+  exit 1
+fi
+
+if grep -q "WARN: ddescribe" karma-output.log; then
+  echo "ERROR: ddescribe caused some tests to be excluded"
+  exit 1
+fi
+
 
 echo '-------------------------'
 echo '-- DOCS: Generate Docs --'

--- a/test/config/init_guinness.dart
+++ b/test/config/init_guinness.dart
@@ -4,5 +4,22 @@ import 'package:unittest/unittest.dart' as unit;
 main() {
   unit.filterStacks = true;
   unit.formatStacks = false;
+
+  _printWarnings();
+
+  guinness.autoInit = false;
   guinness.initSpecs();
 }
+
+_printWarnings () {
+  final info = guinness.suiteInfo();
+
+  if (info.activeIts.any((it) => it.exclusive)) {
+    print("WARN: iit caused some tests to be excluded");
+  }
+
+  if (info.exclusiveDescribes.isNotEmpty) {
+    print("WARN: ddescribe caused some tests to be excluded");
+  }
+}
+


### PR DESCRIPTION
Change the build script to fail when a test was 'itt'ed or 'ddescribe'ed.

Closes #922
