### PR TITLE
fix(cache): Make UnboundedCache extend Cache

### DIFF
--- a/lib/cache/cache.dart
+++ b/lib/cache/cache.dart
@@ -47,7 +47,7 @@ abstract class Cache<K, V> {
 /**
  * An unbounded cache.
  */
-class UnboundedCache<K, V> implements Cache<K, V> {
+class UnboundedCache<K, V> extends Cache<K, V> {
   Map<K, V> _entries = new HashMap<K, V>();
   int _hits = 0;
   int _misses = 0;

--- a/test/core_dom/http_spec.dart
+++ b/test/core_dom/http_spec.dart
@@ -8,9 +8,8 @@ var VALUE = 'val';
 var CACHED_VALUE = 'cached_value';
 
 class FakeCache extends UnboundedCache<String, HttpResponse> {
-  get(x) => x == 'f' ? new HttpResponse(200, CACHED_VALUE) : null;
-  put(_,__) => null;
-
+  HttpResponse get(x) => x == 'f' ? new HttpResponse(200, CACHED_VALUE) : null;
+  HttpResponse put(_,__) => null;
 }
 
 class SubstringRewriter extends UrlRewriter {


### PR DESCRIPTION
The `Cache` implements concrete methods then we should `extends` it, not `implements` it

This fix an analyzer warning

```
Warning: 'FakeCache' doesn't implement 'Cache<String, HttpResponse> clear inherited from Cache<String, HttpResponse>' declared in 'Cache<String, HttpResponse>'.
Try adding an implementation of 'clear' or declaring 'FakeCache' to be 'abstract'.
class FakeCache extends UnboundedCache<String, HttpResponse> {
^^^^^
packages/angular/cache/cache.dart:42:8:
Info: The method 'clear' is declared here in class 'Cache'.
  void clear() => removeAll();
       ^^^^^
base/test/core_dom/http_spec.dart:10:1:
Warning: 'FakeCache' doesn't implement the getter 'length' declared in 'Cache<String, HttpResponse>'.
Try adding an implementation of 'length' or declaring 'FakeCache' to be 'abstract'.
class FakeCache extends UnboundedCache<String, HttpResponse> {
^^^^^
packages/angular/cache/cache.dart:43:11:
Info: The getter 'length' is declared here in class 'Cache'.
  int get length => size;
```

/cc @jbdeboer
