### PR TITLE
refactor(application): change Application not to use the builder pattern

### DIFF
--- a/lib/application.dart
+++ b/lib/application.dart
@@ -148,7 +148,9 @@ abstract class Application {
   /**
    * Creates a selector for a DOM element.
    */
-  dom.Element selector(String selector) => element = _find(selector);
+  void selector(String selector) {
+    element = _find(selector);
+  }
 
   Application(): element = _find('[ng-app]', dom.window.document.documentElement) {
     traceDetectWTF(context);
@@ -158,28 +160,28 @@ abstract class Application {
             ..bind(dom.Node, toFactory: (Application app) => app.element, inject: [Application]);
   }
 
+  void addModule(Module module) {
+    modules.add(module);
+  }
+
+  Injector _injector;
+
   /**
    * Returns the injector for this module.
    */
-  Injector injector;
+  Injector get injector => _injector;
 
-  Application addModule(Module module) {
-    modules.add(module);
-    return this;
-  }
-
-  Application rootContextType(Type rootContext) {
+  void rootContextType(Type rootContext) {
     modules.add(new Module()..bind(Object, toImplementation: rootContext));
-    return this;
   }
 
-  Injector run() {
+  void run() {
     var scope = traceEnter(Application_bootstrap);
     try {
       publishToJavaScript();
       return zone.run(() {
         var rootElements = [element];
-        injector = createInjector();
+        _injector = createInjector();
         ExceptionHandler exceptionHandler = injector.getByKey(EXCEPTION_HANDLER_KEY);
         // Publish cache register interface
         injector.getByKey(JS_CACHE_REGISTER_KEY);
@@ -194,7 +196,6 @@ abstract class Application {
             exceptionHandler(e, s);
           }
         });
-        return injector;
       });
     } finally {
       traceLeave(scope);

--- a/test/core/core_directive_spec.dart
+++ b/test/core/core_directive_spec.dart
@@ -49,7 +49,8 @@ void main() {
         var module = new Module()
             ..bind(Bad1Component);
 
-        var injector = applicationFactory().addModule(module).createInjector();
+        var app = applicationFactory()..addModule(module);
+        var injector = app.createInjector();
         expect(() {
           injector.get(DirectiveMap);
         }).toThrow('Mapping for attribute foo is already defined (while '
@@ -60,7 +61,8 @@ void main() {
         var module = new Module()
             ..bind(Bad2Component);
 
-        var injector = applicationFactory().addModule(module).createInjector();
+        var app = applicationFactory()..addModule(module);
+        var injector = app.createInjector();
         expect(() {
           injector.get(DirectiveMap);
         }).toThrow('Attribute annotation for foo is defined more than once '

--- a/test/core_dom/view_spec.dart
+++ b/test/core_dom/view_spec.dart
@@ -289,9 +289,8 @@ main() {
           ..bind(ADirective)
           ..bind(Node, toFactory: () => document.body, inject: []);
 
-        Injector rootInjector = applicationFactory()
-            .addModule(rootModule)
-            .createInjector();
+        Application app = applicationFactory()..addModule(rootModule);
+        Injector rootInjector = app.createInjector();
         Log log = rootInjector.get(Log);
         Scope rootScope = rootInjector.get(Scope);
 

--- a/test/routing/routing_spec.dart
+++ b/test/routing/routing_spec.dart
@@ -44,10 +44,10 @@ main() {
     });
 
     initRouter(initializer) {
-      var injector = applicationFactory()
-        .addModule(new AngularMockModule())
-        .addModule(new Module()..bind(RouteInitializerFn, toValue: initializer)..bind(MyDirective))
-        .createInjector();
+      var app = applicationFactory()
+          ..addModule(new AngularMockModule())
+          ..addModule(new Module()..bind(RouteInitializerFn, toValue: initializer)..bind(MyDirective));
+      var injector = app.createInjector();
       injector.get(NgRoutingHelper); // force routing initialization
       router = injector.get(Router);
       _ = injector.get(TestBed);


### PR DESCRIPTION
Change the Application class not to use the builder pattern, and instead rely on method cascades.

Depends on #1391
Closes #938
