### PR TITLE
fix(ng-view): cleanup should not destroy an already destroyed scope

### DIFF
--- a/lib/routing/ng_view.dart
+++ b/lib/routing/ng_view.dart
@@ -90,6 +90,7 @@ class NgView implements DetachAware, RouteProvider {
   void detach() {
     _route.discard();
     _locationService._unregisterPortal(this);
+    _cleanUp();
   }
 
   void _show(_View viewDef, Route route, List<Module> modules) {
@@ -128,7 +129,6 @@ class NgView implements DetachAware, RouteProvider {
 
     _view.nodes.forEach((node) => node.remove());
     _childScope.destroy();
-
     _view = null;
     _childScope = null;
   }


### PR DESCRIPTION
Refer https://github.com/angular/angular.dart/issues/1182
and repro https://github.com/chirayuk/sample/tree/issue_1182_leaving_a_nested_ng_view

NgView's register cleanup handlers this way:

```
_leaveSubscription = route.onLeave.listen((_) {
  _leaveSubscription.cancel();
  // …
  _cleanUp();
});
```

When there are nested ng-views, upon a route change, the parent NgView
calls it's _cleanUp() first (which destroys it's child scope) and then
the child NgView attempts a cleanup.  However, it's child scope is
already detached due to the parent NgView cleaning up causing an
exception.

Stack trace is:

```
'package:angular/core/scope.dart': Failed assertion: line 335 pos 12: 'isAttached' is not true.

STACKTRACE:
#0      Scope.destroy (package:angular/core/scope.dart:335:12)
#1      NgView._cleanUp (package:angular/routing/ng_view.dart:130:24)
#2      NgView._show.<anonymous closure> (package:angular/routing/ng_view.dart:106:15)
#3      _rootRunUnary (dart:async/zone.dart:730)
#4      _ZoneDelegate.runUnary (dart:async/zone.dart:462)
#5      _onRunUnary.<anonymous closure> (package:angular/core/zone.dart:113:63)
#6      VmTurnZone._onRunBase (package:angular/core/zone.dart:97:16)
#7      _onRunUnary (package:angular/core/zone.dart:113:17)
#8      _ZoneDelegate.runUnary (dart:async/zone.dart:462)
#9      _CustomizedZone.runUnary (dart:async/zone.dart:667)
#10     _BaseZone.runUnaryGuarded (dart:async/zone.dart:582)
#11     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:333)
#12     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:263)
#13     _SyncBroadcastStreamController._sendData.<anonymous closure> (dart:async/broadcast_stream_controller.dart:344)
#14     _BroadcastStreamController._forEachListener (dart:async/broadcast_stream_controller.dart:297)
#15     _SyncBroadcastStreamController._sendData (dart:async/broadcast_stream_controller.dart:343)
#16     _BroadcastStreamController.add (dart:async/broadcast_stream_controller.dart:227)
#17     Router._leaveCurrentRouteHelper (package:route_hierarchical/client.dart:654:48)
#18     Router._leaveCurrentRouteHelper (package:route_hierarchical/client.dart:656:47)
#19     Router._leaveCurrentRoute (package:route_hierarchical/client.dart:645:41)
#20     Router._leaveOldRoutes (package:route_hierarchical/client.dart:525:30)
#21     Router._processNewRoute (package:route_hierarchical/client.dart:497:27)
#22     Router._route.<anonymous closure> (package:route_hierarchical/client.dart:481:29)
#23     _rootRunUnary (dart:async/zone.dart:730)
#24     _ZoneDelegate.runUnary (dart:async/zone.dart:462)
#25     _onRunUnary.<anonymous closure> (package:angular/core/zone.dart:113:63)
#26     VmTurnZone._onRunBase (package:angular/core/zone.dart:97:16)
#27     _onRunUnary (package:angular/core/zone.dart:113:17)
#28     _ZoneDelegate.runUnary (dart:async/zone.dart:462)
#29     _CustomizedZone.runUnary (dart:async/zone.dart:667)
#30     _Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:488)
#31     _Future._propagateToListeners (dart:async/future_impl.dart:571)
#32     _Future._completeWithValue (dart:async/future_impl.dart:331)
#33     _Future._asyncComplete.<anonymous closure> (dart:async/future_impl.dart:393)
#34     _rootRun (dart:async/zone.dart:723)
#35     _ZoneDelegate.run (dart:async/zone.dart:453)
#36     _onScheduleMicrotask.<anonymous closure> (package:angular/core/zone.dart:117:43)
#37     VmTurnZone._finishTurn (package:angular/core/zone.dart:143:34)
#38     VmTurnZone._onRunBase (package:angular/core/zone.dart:104:43)
#39     _onRunUnary (package:angular/core/zone.dart:113:17)
#40     _ZoneDelegate.runUnary (dart:async/zone.dart:462)
#41     _CustomizedZone.runUnary (dart:async/zone.dart:667)
#42     _BaseZone.runUnaryGuarded (dart:async/zone.dart:582)
#43     _BaseZone.bindUnaryCallback.<anonymous closure> (dart:async/zone.dart:608)
```

Closes #1182
