### PR TITLE
refactor(tests): remove unnecessary inject calls

### DIFF
--- a/test/animate/animation_loop_spec.dart
+++ b/test/animate/animation_loop_spec.dart
@@ -8,11 +8,11 @@ main() {
     TestBed _;
     AnimationLoop runner;
     MockAnimationFrame frame;
-    beforeEach(async(inject((TestBed tb, VmTurnZone zone) {
+    beforeEach(async((TestBed tb, VmTurnZone zone) {
       _ = tb;
       frame = new MockAnimationFrame();
       runner = new AnimationLoop(frame, new Profiler(), zone);
-    })));
+    }));
     
     it('should play animations with window animation frames', async(() {
       var animation = new MockAnimation();

--- a/test/animate/animation_optimizer_spec.dart
+++ b/test/animate/animation_optimizer_spec.dart
@@ -6,10 +6,10 @@ main() {
   describe('AnimationLoop', () {
     TestBed _;
     AnimationOptimizer optimizer;
-    beforeEach(inject((TestBed tb, Expando expand) {
+    beforeEach((TestBed tb, Expando expand) {
       _ = tb;
       optimizer = new AnimationOptimizer(expand);
-    }));
+    });
     
     it('should prevent animations on child elements', () {
       var animation = new NoOpAnimation();

--- a/test/animate/css_animate_spec.dart
+++ b/test/animate/css_animate_spec.dart
@@ -10,12 +10,12 @@ main() {
     Animate animate;
     MockAnimationLoop runner;
 
-    beforeEach(inject((TestBed tb, Expando expand) {
+    beforeEach((TestBed tb, Expando expand) {
       _ = tb;
       runner = new MockAnimationLoop();
       animate = new CssAnimate(runner,
           new CssAnimationMap(), new AnimationOptimizer(expand));
-    }));
+    });
 
     it('should add a css class to an element node', async(() {
       _.compile('<div></div>');

--- a/test/animate/css_animation_spec.dart
+++ b/test/animate/css_animation_spec.dart
@@ -6,7 +6,7 @@ main() {
   describe('CssAnimation', () {
     TestBed _;
 
-    beforeEach(inject((TestBed tb) => _ = tb));
+    beforeEach((TestBed tb) => _ = tb);
     afterEach(() => _.rootElements.forEach((e) => e.remove()));
     
     it('should correctly respond to an animation lifecycle', async(() {

--- a/test/cache/cache_spec.dart
+++ b/test/cache/cache_spec.dart
@@ -67,17 +67,17 @@ void main() {
 
       describe('put, get & remove', () {
 
-        it('should add cache entries via add and retrieve them via get', inject(() {
+        it('should add cache entries via add and retrieve them via get', () {
           var obj = {'bar':'baz'};
           cache.put('key1', 'bar');
           cache.put('key2', obj);
 
           expect(cache.get('key2')).toBe(obj);
           expect(cache.get('key1')).toBe('bar');
-        }));
+        });
 
 
-        it('should remove entries via remove', inject(() {
+        it('should remove entries via remove', () {
           cache.put('k1', 'foo');
           cache.put('k2', 'bar');
 
@@ -90,22 +90,22 @@ void main() {
 
           expect(cache.get('k1')).toBeNull();
           expect(cache.get('k2')).toBeNull();
-        }));
+        });
 
 
-        it('should return null when entry does not exist', inject(() {
+        it('should return null when entry does not exist', () {
           expect(cache.remove('non-existent')).toBeNull();
-        }));
+        });
 
-        it("should return value from put", inject(() {
+        it("should return value from put", () {
           var obj = {};
           expect(cache.put('k1', obj)).toBe(obj);
-        }));
+        });
       });
 
 
       describe('removeAll', () {
-        it('should blow away all data', inject(() {
+        it('should blow away all data', () {
           cache.put('id1', 1);
           cache.put('id2', 2);
           cache.put('id3', 3);
@@ -115,13 +115,13 @@ void main() {
           expect(cache.get('id1')).toBeNull();
           expect(cache.get('id2')).toBeNull();
           expect(cache.get('id3')).toBeNull();
-        }));
+        });
       });
     });
 
     // TODO(chirayu): Add a lot more tests and tests and don't rely on toString()
     describe('LRU cache', () {
-      it('should have LRU behavior with ordering keys and eviction', inject(() {
+      it('should have LRU behavior with ordering keys and eviction', () {
         var cache = new LruCache<int, int>(capacity: 4);
         cache.put(1, 10);
         cache.put(2, 20);
@@ -146,7 +146,7 @@ void main() {
         expect(stats.size).toEqual(0);
         expect(stats.hits).toEqual(2);
         expect(stats.misses).toEqual(1);
-      }));
+      });
 
       it('should hold nothing if capacity is zero', () {
         var cache = new LruCache<int, int>(capacity: 0);

--- a/test/change_detection/watch_group_spec.dart
+++ b/test/change_detection/watch_group_spec.dart
@@ -23,7 +23,7 @@ void main() {
     Parser parser;
     ASTParser astParser;
 
-    beforeEach(inject((Logger _logger, Parser _parser, ASTParser _astParser) {
+    beforeEach((Logger _logger, Parser _parser, ASTParser _astParser) {
       context = {};
       var getterFactory = new DynamicFieldGetterFactory();
       changeDetector = new DirtyCheckingChangeDetector(getterFactory);
@@ -31,7 +31,7 @@ void main() {
       logger = _logger;
       parser = _parser;
       astParser = _astParser;
-    }));
+    });
 
     AST parse(String expression) => astParser(expression);
 
@@ -64,13 +64,13 @@ void main() {
       expect(logger).toEqual(list);
     }
 
-    beforeEach(inject((Logger _logger) {
+    beforeEach((Logger _logger) {
       context = {};
       var getterFactory = new DynamicFieldGetterFactory();
       changeDetector = new DirtyCheckingChangeDetector(getterFactory);
       watchGrp = new RootWatchGroup(getterFactory, changeDetector, context);
       logger = _logger;
-    }));
+    });
 
     it('should have a toString for debugging', () {
       watchGrp.watch(parse('a'), (v, p) {});

--- a/test/core/scope_spec.dart
+++ b/test/core/scope_spec.dart
@@ -654,7 +654,7 @@ void main() {
 
 
           it('should skip scopes which dont have given event',
-          inject((RootScope rootScope, Logger log) {
+          (RootScope rootScope, Logger log) {
             var child1 = rootScope.createChild('A');
             rootScope.createChild('A1');
             rootScope.createChild('A2');
@@ -663,7 +663,7 @@ void main() {
             child2.on('event').listen((e) => log(e.data));
             rootScope.broadcast('event', 'OK');
             expect(log).toEqual(['OK']);
-          }));
+          });
         });
 
 
@@ -847,14 +847,14 @@ void main() {
         });
 
 
-        it(r'should execute and return value and update', inject(
-                (RootScope rootScope, ExceptionHandler e) {
-              LoggingExceptionHandler exceptionHandler = e;
-              rootScope.context['name'] = 'abc';
-              expect(rootScope.apply((context) => context['name'])).toEqual('abc');
-              expect(log).toEqual('digest;digest;');
-              exceptionHandler.assertEmpty();
-            }));
+        it(r'should execute and return value and update',
+            (RootScope rootScope, ExceptionHandler e) {
+          LoggingExceptionHandler exceptionHandler = e;
+          rootScope.context['name'] = 'abc';
+          expect(rootScope.apply((context) => context['name'])).toEqual('abc');
+          expect(log).toEqual('digest;digest;');
+          exceptionHandler.assertEmpty();
+        });
 
 
         it(r'should execute and return value and update', (RootScope rootScope) {
@@ -924,14 +924,14 @@ void main() {
           exceptionHandler.assertEmpty();
         });
 
-        it(r'should execute and return value and update', inject(
-                (RootScope rootScope, ExceptionHandler e) {
-              LoggingExceptionHandler exceptionHandler = e;
-              rootScope.context['name'] = 'abc';
-              expect(rootScope.apply((context) => context['name'])).toEqual('abc');
-              expect(log).toEqual('digest;digest;');
-              exceptionHandler.assertEmpty();
-            }));
+        it(r'should execute and return value and update',
+            (RootScope rootScope, ExceptionHandler e) {
+          LoggingExceptionHandler exceptionHandler = e;
+          rootScope.context['name'] = 'abc';
+          expect(rootScope.apply((context) => context['name'])).toEqual('abc');
+          expect(log).toEqual('digest;digest;');
+          exceptionHandler.assertEmpty();
+        });
 
         it(r'should execute and return value and update', (RootScope rootScope) {
           rootScope.context['name'] = 'abc';
@@ -1092,23 +1092,22 @@ void main() {
       });
 
 
-      it(r'should run digest multiple times', inject(
-              (RootScope rootScope) {
-            // tests a traversal edge case which we originally missed
-            var log = [];
-            var childA = rootScope.createChild({'log': log});
-            var childB = rootScope.createChild({'log': log});
+      it(r'should run digest multiple times', (RootScope rootScope) {
+        // tests a traversal edge case which we originally missed
+        var log = [];
+        var childA = rootScope.createChild({'log': log});
+        var childB = rootScope.createChild({'log': log});
 
-            rootScope.context['log'] = log;
+        rootScope.context['log'] = log;
 
-            rootScope.watch("log.add('r')", (_, __) => null);
-            childA.watch("log.add('a')", (_, __) => null);
-            childB.watch("log.add('b')", (_, __) => null);
+        rootScope.watch("log.add('r')", (_, __) => null);
+        childA.watch("log.add('a')", (_, __) => null);
+        childB.watch("log.add('b')", (_, __) => null);
 
-            // init
-            rootScope.digest();
-            expect(log.join('')).toEqual('rabrab');
-          }));
+        // init
+        rootScope.digest();
+        expect(log.join('')).toEqual('rabrab');
+      });
 
 
       it(r'should repeat watch cycle while model changes are identified', (RootScope rootScope) {
@@ -1165,7 +1164,7 @@ void main() {
       });
 
 
-      it(r'should return a function that allows listeners to be unregistered', inject(
+      it(r'should return a function that allows listeners to be unregistered',
           (RootScope rootScope) {
         var listener = guinness.createSpy('watch listener');
         var watch;
@@ -1185,7 +1184,7 @@ void main() {
         watch.remove();
         rootScope.digest(); //trigger
         expect(listener).not.toHaveBeenCalled();
-      }));
+      });
 
 
       it(r'should be possible to remove every watch',
@@ -1242,7 +1241,7 @@ void main() {
 
 
       it(r'should always call the watchr with newVal and oldVal equal on the first run',
-      inject((RootScope rootScope) {
+          (RootScope rootScope) {
         var log = [];
         var logger = (newVal, oldVal) {
           var val = (newVal == oldVal || (newVal != oldVal && oldVal != newVal)) ? newVal : 'xxx';
@@ -1267,7 +1266,7 @@ void main() {
         log = [];
         rootScope.digest();
         expect(log).toEqual([]);
-      }));
+      });
 
 
       it('should properly watch constants', (RootScope rootScope, Logger log) {

--- a/test/core/templateurl_spec.dart
+++ b/test/core/templateurl_spec.dart
@@ -53,7 +53,7 @@ void main() {
             ..bind(UrlRewriter, toImplementation: PrefixedUrlRewriter);
       });
 
-      it('should use the UrlRewriter for both HTML and CSS URLs', async(inject(
+      it('should use the UrlRewriter for both HTML and CSS URLs', async(
           (Http http, Compiler compile, Scope rootScope, Logger log,
            Injector injector, VmTurnZone zone, MockHttpBackend backend,
            DirectiveMap directives) {
@@ -74,7 +74,7 @@ void main() {
         expect(element.children[0].shadowRoot).toHaveHtml(
             '<style>.hello{}</style><div log="SIMPLE">Simple!</div>'
         );
-      })));
+      }));
     });
 
 
@@ -88,7 +88,7 @@ void main() {
             ..bind(InlineWithCssComponent);
       });
 
-      it('should replace element with template from url', async(inject(
+      it('should replace element with template from url', async(
           (Http http, Compiler compile, Scope rootScope,  Logger log,
            Injector injector, MockHttpBackend backend, DirectiveMap directives) {
         backend.expectGET('simple.html').respond(200, '<div log="SIMPLE">Simple!</div>');
@@ -104,9 +104,9 @@ void main() {
         rootScope.apply();
         // Note: There is no ordering.  It is who ever comes off the wire first!
         expect(log.result()).toEqual('LOG; SIMPLE');
-      })));
+      }));
 
-      it('should load template from URL once', async(inject(
+      it('should load template from URL once', async(
           (Http http, Compiler compile, Scope rootScope,  Logger log,
            Injector injector, MockHttpBackend backend, DirectiveMap directives) {
         backend.whenGET('simple.html').respond(200, '<div log="SIMPLE">Simple!</div>');
@@ -127,9 +127,9 @@ void main() {
 
         // Note: There is no ordering.  It is who ever comes off the wire first!
         expect(log.result()).toEqual('LOG; LOG; SIMPLE; SIMPLE');
-      })));
+      }));
 
-      it('should load a CSS file into a style', async(inject(
+      it('should load a CSS file into a style', async(
           (Http http, Compiler compile, Scope rootScope, Logger log,
            Injector injector, MockHttpBackend backend, DirectiveMap directives) {
         backend
@@ -150,9 +150,9 @@ void main() {
         rootScope.apply();
         // Note: There is no ordering.  It is who ever comes off the wire first!
         expect(log.result()).toEqual('LOG; SIMPLE');
-      })));
+      }));
 
-      it('should load a CSS file with a \$template', async(inject(
+      it('should load a CSS file with a \$template', async(
           (Http http, Compiler compile, Scope rootScope, Injector injector,
            MockHttpBackend backend, DirectiveMap directives) {
         var element = es('<div><inline-with-css log>ignore</inline-with-css><div>');
@@ -163,9 +163,9 @@ void main() {
         backend.flush();
         microLeap();
         expect(element[0]).toHaveText('.hello{}inline!');
-      })));
+      }));
 
-      it('should ignore CSS load errors ', async(inject(
+      it('should ignore CSS load errors ', async(
           (Http http, Compiler compile, Scope rootScope, Injector injector,
            MockHttpBackend backend, DirectiveMap directives) {
         var element = es('<div><inline-with-css log>ignore</inline-with-css><div>');
@@ -180,9 +180,9 @@ void main() {
             'HTTP 500: some error\n'
             '*/\n'
             'inline!');
-      })));
+      }));
 
-      it('should load a CSS with no template', async(inject(
+      it('should load a CSS with no template', async(
           (Http http, Compiler compile, Scope rootScope, Injector injector,
            MockHttpBackend backend, DirectiveMap directives) {
         var element = es('<div><only-css log>ignore</only-css><div>');
@@ -193,9 +193,9 @@ void main() {
         backend.flush();
         microLeap();
         expect(element[0]).toHaveText('.hello{}');
-      })));
+      }));
 
-      it('should load the CSS before the template is loaded', async(inject(
+      it('should load the CSS before the template is loaded', async(
           (Http http, Compiler compile, Scope rootScope, Injector injector,
            MockHttpBackend backend, DirectiveMap directives) {
         backend
@@ -209,7 +209,7 @@ void main() {
         backend.flush();
         microLeap();
         expect(element.first).toHaveText('.hello{}Simple!');
-      })));
+      }));
     });
 
     describe('multiple css loading', () {
@@ -219,7 +219,7 @@ void main() {
             ..bind(HtmlAndMultipleCssComponent);
       });
 
-      it('should load multiple CSS files into a style', async(inject(
+      it('should load multiple CSS files into a style', async(
           (Http http, Compiler compile, Scope rootScope, Logger log,
            Injector injector, MockHttpBackend backend, DirectiveMap directives) {
         backend
@@ -241,7 +241,7 @@ void main() {
         rootScope.apply();
         // Note: There is no ordering.  It is who ever comes off the wire first!
         expect(log.result()).toEqual('LOG; SIMPLE');
-      })));
+      }));
     });
 
     describe('style cache', () {
@@ -251,7 +251,7 @@ void main() {
             ..bind(TemplateCache, toValue: new TemplateCache(capacity: 0));
       });
 
-      it('should load css from the style cache for the second component', async(inject(
+      it('should load css from the style cache for the second component', async(
           (Http http, Compiler compile, MockHttpBackend backend,
            DirectiveMap directives, Injector injector) {
         backend
@@ -277,7 +277,7 @@ void main() {
         expect(element2.children[0].shadowRoot).toHaveHtml(
             '<style>.hello{}</style><div log="SIMPLE">Simple!</div>'
         );
-      })));
+      }));
     });
   });
 }

--- a/test/core_dom/compiler_spec.dart
+++ b/test/core_dom/compiler_spec.dart
@@ -55,7 +55,7 @@ void main() {
           ..bind(SimpleComponent);
     });
 
-    beforeEach(inject((TestBed tb) => _ = tb));
+    beforeEach((TestBed tb) => _ = tb);
 
     it('should correctly detach transcluded content when scope destroyed', async(() {
       var scope = _.rootScope.createChild({});
@@ -88,7 +88,7 @@ void main() {
           ..bind(MyChildController);
     });
 
-    beforeEach(inject((TestBed tb) => _ = tb));
+    beforeEach((TestBed tb) => _ = tb);
 
     it('should compile basic hello world', () {
       var element = _.compile('<div ng-bind="name"></div>');
@@ -778,7 +778,7 @@ void main() {
 
           Expando expando;
 
-          beforeEach(inject((Expando _expando) => expando = _expando));
+          beforeEach((Expando _expando) => expando = _expando);
 
           ['shadowy', 'shadowless'].forEach((selector) {
             it('should release expando when a node is freed ($selector)', async(() {

--- a/test/core_dom/event_handler_spec.dart
+++ b/test/core_dom/event_handler_spec.dart
@@ -45,7 +45,7 @@ main() {
       return ngAppElement.firstChild;
     }
 
-    it('should register and handle event', inject((TestBed _) {
+    it('should register and handle event', (TestBed _) {
       var e = compile(_,
         '''<div foo>
           <div on-abc="ctrl.invoked=true;"></div>
@@ -53,9 +53,9 @@ main() {
 
       _.triggerEvent(e.querySelector('[on-abc]'), 'abc');
       expect(_.getScope(e).context['ctrl'].invoked).toEqual(true);
-    }));
+    });
 
-    it('shoud register and handle event with long name', inject((TestBed _) {
+    it('shoud register and handle event with long name', (TestBed _) {
       var e = compile(_,
         '''<div foo>
           <div on-my-new-event="ctrl.invoked=true;"></div>
@@ -64,9 +64,9 @@ main() {
       _.triggerEvent(e.querySelector('[on-my-new-event]'), 'myNewEvent');
       var fooScope = _.getScope(e);
       expect(fooScope.context['ctrl'].invoked).toEqual(true);
-    }));
+    });
 
-    it('shoud have model updates applied correctly', inject((TestBed _) {
+    it('shoud have model updates applied correctly', (TestBed _) {
       var e = compile(_,
         '''<div foo>
           <div on-abc='ctrl.description="new description";'>{{ctrl.description}}</div>
@@ -75,7 +75,7 @@ main() {
       el.dispatchEvent(new Event('abc'));
       _.rootScope.apply();
       expect(el.text).toEqual("new description");
-    }));
+    });
 
     it('shoud register event when shadow dom is used', async((TestBed _) {
       var e = compile(_,'<bar></bar>');
@@ -89,7 +89,7 @@ main() {
       expect(ctrl.invoked).toEqual(true);
     }));
 
-    it('shoud handle event within content only once', async(inject((TestBed _) {
+    it('shoud handle event within content only once', async((TestBed _) {
       var e = compile(_,
         '''<div foo>
              <bar>
@@ -106,6 +106,6 @@ main() {
 
       var fooScope = _.getScope(document.querySelector('[foo]'));
       expect(fooScope.context['ctrl'].invoked).toEqual(true);
-    })));
+    }));
   });
 }

--- a/test/core_dom/mustache_spec.dart
+++ b/test/core_dom/mustache_spec.dart
@@ -9,10 +9,10 @@ main() {
       module.bind(_HelloFormatter);
       module.bind(_FooDirective);
     });
-    beforeEach(inject((TestBed tb) => _ = tb));
+    beforeEach((TestBed tb) => _ = tb);
 
-    it('should replace {{}} in text', inject((Compiler compile,
-        Scope rootScope, Injector injector, DirectiveMap directives)
+    it('should replace {{}} in text', (Compiler compile, Scope rootScope,
+        Injector injector, DirectiveMap directives)
     {
       var element = es('<div>{{name}}<span>!</span></div>');
       var template = compile(element, directives);
@@ -24,7 +24,7 @@ main() {
 
       rootScope.apply();
       expect(element).toHaveText('OK!');
-    }));
+    });
 
     describe('observe/flush phase', () {
       it('should first only when then value has settled', async((Logger log) {
@@ -44,9 +44,8 @@ main() {
       }));
     });
 
-    it('should replace {{}} in attribute', inject((Compiler compile,
-        Scope rootScope, Injector injector, DirectiveMap directives)
-    {
+    it('should replace {{}} in attribute', (Compiler compile, Scope rootScope,
+        Injector injector, DirectiveMap directives) {
       Element element =
           e('<div some-attr="{{name}}" other-attr="{{age}}"></div>');
       var template = compile([element], directives);
@@ -60,12 +59,11 @@ main() {
       rootScope.apply();
       expect(element.attributes['some-attr']).toEqual('OK');
       expect(element.attributes['other-attr']).toEqual('23');
-    }));
+    });
 
 
-    it('should allow newlines in attribute', inject((Compiler compile,
-       RootScope rootScope, Injector injector, DirectiveMap directives)
-    {
+    it('should allow newlines in attribute', (Compiler compile,
+        RootScope rootScope, Injector injector, DirectiveMap directives) {
       Element element =
           e('<div multiline-attr="line1: {{line1}}\nline2: {{line2}}"></div>');
       var template = compile([element], directives);
@@ -79,12 +77,11 @@ main() {
       rootScope.apply();
       expect(element.attributes['multiline-attr'])
           .toEqual('line1: L1\nline2: L2');
-    }));
+    });
 
 
-    it('should handle formatters', inject((Compiler compile, RootScope rootScope,
-        Injector injector, DirectiveMap directives)
-    {
+    it('should handle formatters', (Compiler compile, RootScope rootScope,
+        Injector injector, DirectiveMap directives) {
       var element = es('<div>{{"World" | hello}}</div>');
       var template = compile(element, directives);
       var view = template(injector);
@@ -93,13 +90,13 @@ main() {
       element = view.nodes;
 
       expect(element).toHaveHtml('Hello, World!');
-    }));
+    });
   });
 
   describe('NgShow', () {
     TestBed _;
 
-    beforeEach(inject((TestBed tb) => _ = tb));
+    beforeEach((TestBed tb) => _ = tb);
 
     it('should add/remove ng-hide class', () {
       var element = _.compile('<div ng-show="isVisible"></div>');

--- a/test/directive/ng_repeat_spec.dart
+++ b/test/directive/ng_repeat_spec.dart
@@ -531,7 +531,7 @@ main() {
     });
 
     it(r'should not move blocks when elements only added or removed',
-    inject((Injector injector) {
+      (Injector injector) {
       var throwOnMove = new MockAnimate();
       var child = injector.createChild(
           [new Module()..bind(Animate, toValue: throwOnMove)]);
@@ -566,6 +566,6 @@ main() {
            ..apply();
 
       expect(element).toHaveText('bc');
-    }));
+    });
   });
 }

--- a/test/directive/ng_switch_spec.dart
+++ b/test/directive/ng_switch_spec.dart
@@ -94,8 +94,7 @@ void main() {
     });
 
 
-    it('should always display the elements that do not match a switch',
-    inject(() {
+    it('should always display the elements that do not match a switch', () {
       var element = _.compile(
           '<ul ng-switch="select">' +
           '<li>always </li>' +
@@ -109,7 +108,7 @@ void main() {
       _.rootScope.context['select'] = 1;
       _.rootScope.apply();
       expect(element.text).toEqual('always one ');
-    }));
+    });
 
 
     it('should display the elements that do not have ngSwitchWhen nor ' +
@@ -137,8 +136,7 @@ void main() {
 
     it('should display the elements that do not have ngSwitchWhen nor ' +
     'ngSwitchDefault at the position specified in the template when the ' +
-    'first and last elements in the ngSwitch have a ngSwitch* directive',
-    inject(() {
+    'first and last elements in the ngSwitch have a ngSwitch* directive', () {
       var element = _.compile(
           '<ul ng-switch="select">' +
           '<li ng-switch-when="1">2</li>' +
@@ -153,7 +151,7 @@ void main() {
       _.rootScope.context['select'] = 1;
       _.rootScope.apply();
       expect(element.text).toEqual('236');
-    }));
+    });
 
 
     it('should call change on switch', () {

--- a/test/formatter/json_spec.dart
+++ b/test/formatter/json_spec.dart
@@ -4,9 +4,9 @@ import '../_specs.dart';
 
 void main() {
   describe('json', () {
-    it('should convert primitives, array, map to json', inject((Scope scope, Parser parser, FormatterMap formatters) {
+    it('should convert primitives, array, map to json', (Scope scope, Parser parser, FormatterMap formatters) {
       scope.context['foo'] = [{"string":'foo', "number": 123, "bool": false}];
       expect(parser('foo | json').eval(scope.context, formatters)).toEqual('[{"string":"foo","number":123,"bool":false}]');
-    }));
+    });
   });
 }

--- a/test/formatter/lowercase_spec.dart
+++ b/test/formatter/lowercase_spec.dart
@@ -4,9 +4,9 @@ import '../_specs.dart';
 
 void main() {
   describe('lowercase', () {
-    it('should convert string to lowercase', inject((Parser parse, FormatterMap formatters) {
+    it('should convert string to lowercase', (Parser parse, FormatterMap formatters) {
       expect(parse('null | lowercase').eval(null, formatters)).toEqual(null);
       expect(parse('"FOO" | lowercase').eval(null, formatters)).toEqual('foo');
-    }));
+    });
   });
 }

--- a/test/mock/test_bed_spec.dart
+++ b/test/mock/test_bed_spec.dart
@@ -14,20 +14,17 @@ void main() {
       return (TestBed tb) => _ = tb;
     });
 
-    it('should allow for a scope-based compile', () {
+    it('should allow for a scope-based compile', (Scope scope) {
+      Scope childScope = scope.createChild({});
 
-      inject((Scope scope) {
-        Scope childScope = scope.createChild({});
+      _.compile('<div my-directive probe="i"></div>', scope: childScope);
 
-        _.compile('<div my-directive probe="i"></div>', scope: childScope);
+      Probe probe = _.rootScope.context['i'];
+      var directiveInst = probe.directive(MyTestBedDirective);
 
-        Probe probe = _.rootScope.context['i'];
-        var directiveInst = probe.directive(MyTestBedDirective);
+      childScope.destroy();
 
-        childScope.destroy();
-
-        expect(directiveInst.destroyed).toBe(true);
-      });
+      expect(directiveInst.destroyed).toBe(true);
     });
 
   });


### PR DESCRIPTION
Some tests rely on the fact that dependencies can be injected into `it`s, but some call `inject` explicitly. This PR makes tests more consistent by removing all the unnecessary inject calls.
