### PR TITLE
perf(bp): add min/max numbers to bp report

### DIFF
--- a/benchmark/web/bp.js
+++ b/benchmark/web/bp.js
@@ -177,7 +177,9 @@ bp.Report.getTimesPerAction = function(name) {
       tpa[c] = {
         recent: undefined,
         history: [],
-        avg: {}
+        avg: {},
+        min: Number.MAX_VALUE,
+        max: Number.MIN_VALUE
       };
     });
   }
@@ -194,9 +196,12 @@ bp.Report.rightSizeTimes = function(times) {
 };
 
 bp.Report.updateTimes = function(tpa, index, reference, recentTime) {
-  tpa[reference].recent = recentTime;
-  tpa[reference].history[index] = recentTime;
-  tpa[reference].history = bp.Report.rightSizeTimes(tpa[reference].history);
+  var curTpa = tpa[reference];
+  curTpa.recent = recentTime;
+  curTpa.history[index] = recentTime;
+  curTpa.history = bp.Report.rightSizeTimes(curTpa.history);
+  curTpa.min = Math.min(curTpa.min, recentTime);
+  curTpa.max = Math.max(curTpa.max, recentTime);
 };
 
 bp.Report.calcStats = function() {

--- a/benchmark/web/tree.html
+++ b/benchmark/web/tree.html
@@ -70,6 +70,9 @@
                 &plusmn; <%= Math.round(testTime.avg.coefficientOfVariation * 100) %>%
                 <br>
                 (stddev <%= testTime.avg.stdDev.toFixed(2) %>)
+                <br>
+                (min <%= testTime.min.toFixed(2) %> /
+                 max <%= testTime.max.toFixed(2) %>)
               </div>
               <div class="td col-md-2">
                 mean: <%= gcTime.avg.mean.toFixed(2) %>ms


### PR DESCRIPTION
The benchmark fluctuates quite a bit (even with the last 20 window), so I find the minimum time taken useful.
