### PR TITLE
fix: missing exception detail in bindings

### DIFF
--- a/lib/core/parser/parser_dynamic.dart
+++ b/lib/core/parser/parser_dynamic.dart
@@ -48,7 +48,7 @@ class DynamicClosureMap implements ClosureMap {
         try {
           return reflect(o).invoke(symbol, posArgs, sNamedArgs).reflectee;
         } on NoSuchMethodError catch (e) {
-          throw 'Undefined function $name';
+          throw 'Undefined function or exception in $name $e';
         }
       }
     };


### PR DESCRIPTION
For a binding such as <input ng-change="ctrl.foo()"> , if an exception happens inside foo() the exception is misleading and the original exception is not reported.
