### PR TITLE
perf(dccd): Drop useless checks

### DIFF
--- a/lib/change_detection/dirty_checking_change_detector.dart
+++ b/lib/change_detection/dirty_checking_change_detector.dart
@@ -175,12 +175,12 @@ class DirtyCheckingChangeDetectorGroup<H> implements ChangeDetectorGroup<H> {
 
   DirtyCheckingRecord _recordAdd(DirtyCheckingRecord record) {
     DirtyCheckingRecord previous = _recordTail;
-    DirtyCheckingRecord next = previous == null ? null : previous._nextRecord;
+    DirtyCheckingRecord next = previous._nextRecord;
 
     record._nextRecord = next;
     record._prevRecord = previous;
 
-    if (previous != null) previous._nextRecord = record;
+    previous._nextRecord = record;
     if (next != null) next._prevRecord = record;
 
     _recordTail = record;
@@ -194,7 +194,8 @@ class DirtyCheckingChangeDetectorGroup<H> implements ChangeDetectorGroup<H> {
     DirtyCheckingRecord previous = record._prevRecord;
     DirtyCheckingRecord next = record._nextRecord;
 
-    if (record == _recordHead && record == _recordTail) {
+    if (_recordHead == _recordTail) {
+      assert(record == _recordHead);
       // we are the last one, must leave marker behind.
       _recordHead = _recordTail = _marker;
       _marker._nextRecord = next;


### PR DESCRIPTION
in _recordAdd(), previous could never be null as the list is never empty (it has at least a marker).
in _recordRemove(), when the list is composed of a single record, it must be the record we're trying to remove (and we assert that).

The perf gain should be marginal and is not reliably measure with the wg benchmark (hidden by the noise)
