### PR TITLE
feat(DirectiveInjector): add a toInstanceOf parameter to bind()

### DIFF
--- a/lib/core/annotation_src.dart
+++ b/lib/core/annotation_src.dart
@@ -3,7 +3,12 @@ library angular.core.annotation_src;
 import "package:di/di.dart" show Injector, Visibility, Factory;
 
 abstract class DirectiveBinder {
-  bind(key, {Function toFactory, inject, Visibility visibility: Visibility.CHILDREN});
+ void bind(key, {dynamic toValue,
+                 Function toFactory,
+                 Type toImplementation,
+                 toInstanceOf,
+                 inject: const[],
+                 Visibility visibility: Visibility.LOCAL});
 }
 
 typedef void DirectiveBinderFn(DirectiveBinder module);

--- a/lib/core_dom/directive_injector.dart
+++ b/lib/core_dom/directive_injector.dart
@@ -99,7 +99,7 @@ class DirectiveInjector implements DirectiveBinder {
       , EVENT_HANDLER_KEY
       , KEEP_ME_LAST
       ];
-  
+
   final DirectiveInjector parent;
   final Injector appInjector;
   final Node _node;
@@ -138,7 +138,7 @@ class DirectiveInjector implements DirectiveBinder {
     }
   }
 
-  static Binding _temp_binding = new Binding();
+  static Binding _tempBinding = new Binding();
 
   DirectiveInjector(parent, appInjector, this._node, this._nodeAttrs, this._eventHandler,
                     this.scope, this._animate)
@@ -152,21 +152,23 @@ class DirectiveInjector implements DirectiveBinder {
         scope = null,
         _animate = null;
 
-  bind(key, {dynamic toValue: DEFAULT_VALUE,
+  void bind(key, {dynamic toValue: DEFAULT_VALUE,
             Function toFactory: DEFAULT_VALUE,
-            Type toImplementation, inject: const[],
+            Type toImplementation,
+            toInstanceOf,
+            inject: const[],
             Visibility visibility: Visibility.LOCAL}) {
     if (key == null) throw 'Key is required';
     if (key is! Key) key = new Key(key);
     if (inject is! List) inject = [inject];
 
-    _temp_binding.bind(key, Module.DEFAULT_REFLECTOR, toValue: toValue, toFactory: toFactory,
-              toImplementation: toImplementation, inject: inject);
+    _tempBinding.bind(key, Module.DEFAULT_REFLECTOR, toValue: toValue, toFactory: toFactory,
+        toImplementation: toImplementation, inject: inject, toInstanceOf: toInstanceOf);
 
-    bindByKey(key, _temp_binding.factory, _temp_binding.parameterKeys, visibility);
+    bindByKey(key, _tempBinding.factory, _tempBinding.parameterKeys, visibility);
   }
 
-  bindByKey(Key key, Function factory, List<Key> parameterKeys, [Visibility visibility]) {
+  void bindByKey(Key key, Function factory, List<Key> parameterKeys, [Visibility visibility]) {
     if (visibility == null) visibility = Visibility.CHILDREN;
     int visibilityId = _toVisId(visibility);
     int keyVisId = key.uid;
@@ -211,7 +213,7 @@ class DirectiveInjector implements DirectiveBinder {
     return isDirective ? _getDirectiveByKey(key, uid, appInjector) : _getById(uid);
   }
 
-  _getDirectiveByKey(Key k, int visType, Injector i) {
+  Object _getDirectiveByKey(Key k, int visType, Injector i) {
     do {
       if (_key0 == null) break; if (identical(_key0, k)) return _obj0 == null ?  _obj0 = _new(_pKeys0, _factory0) : _obj0;
       if (_key1 == null) break; if (identical(_key1, k)) return _obj1 == null ?  _obj1 = _new(_pKeys1, _factory1) : _obj1;
@@ -340,7 +342,7 @@ class TemplateDirectiveInjector extends DirectiveInjector {
   final ViewFactory _viewFactory;
   ViewPort _viewPort;
   BoundViewFactory _boundViewFactory;
-  
+
   TemplateDirectiveInjector(DirectiveInjector parent, Injector appInjector,
                        Node node, NodeAttrs nodeAttrs, EventHandler eventHandler,
                        Scope scope, Animate animate, this._viewFactory)
@@ -357,7 +359,7 @@ class TemplateDirectiveInjector extends DirectiveInjector {
       default: return super._getById(keyId);
     }
   }
-  
+
 }
 
 abstract class ComponentDirectiveInjector extends DirectiveInjector {

--- a/lib/core_dom/element_binder.dart
+++ b/lib/core_dom/element_binder.dart
@@ -23,20 +23,6 @@ class TemplateElementBinder extends ElementBinder {
   String toString() => "[TemplateElementBinder template:$template]";
 }
 
-// TODO: This class exists for forwards API compatibility only.
-//       Remove it after migration to DI 2.0.
-class _DirectiveBinderImpl implements DirectiveBinder {
-  final module = new Module();
-
-  _DirectiveBinderImpl();
-
-  bind(key, {Function toFactory: DEFAULT_VALUE, List inject: null,
-      Visibility visibility: Directive.LOCAL_VISIBILITY}) {
-    module.bind(key, toFactory: toFactory, inject: inject,
-        visibility: visibility);
-  }
-}
-
 /**
  * ElementBinder is created by the Selector and is responsible for instantiating
  * individual directives and binding element properties.

--- a/lib/directive/ng_form.dart
+++ b/lib/directive/ng_form.dart
@@ -20,7 +20,7 @@ part of angular.directive;
     map: const { 'ng-form': '@name' })
 class NgForm extends NgControl {
   static module(DirectiveBinder binder) =>
-    binder.bind(NgControl, inject: NG_FORM_KEY, visibility: Visibility.CHILDREN);
+      binder.bind(NgControl, toInstanceOf: NG_FORM_KEY, visibility: Visibility.CHILDREN);
 
   final Scope _scope;
 

--- a/lib/routing/ng_bind_route.dart
+++ b/lib/routing/ng_bind_route.dart
@@ -31,8 +31,8 @@ class NgBindRoute implements RouteProvider {
   final Router _router;
   final DirectiveInjector _injector;
 
-  static void module(DirectiveBinder binder)
-      => binder.bind(RouteProvider, inject: NG_BIND_ROUTE_KEY, visibility: Visibility.CHILDREN);
+  static void module(DirectiveBinder binder) =>
+      binder.bind(RouteProvider, toInstanceOf: NG_BIND_ROUTE_KEY, visibility: Visibility.CHILDREN);
 
   // We inject NgRoutingHelper to force initialization of routing.
   NgBindRoute(this._router, this._injector, NgRoutingHelper _);

--- a/lib/routing/ng_view.dart
+++ b/lib/routing/ng_view.dart
@@ -56,8 +56,8 @@ part of angular.routing;
     module: NgView.module,
     visibility: Visibility.CHILDREN)
 class NgView implements DetachAware, RouteProvider {
-  static void module(DirectiveBinder binder)
-      => binder.bind(RouteProvider, inject: NG_VIEW_KEY, visibility: Visibility.CHILDREN);
+  static void module(DirectiveBinder binder) =>
+      binder.bind(RouteProvider, toInstanceOf: NG_VIEW_KEY, visibility: Visibility.CHILDREN);
 
   final NgRoutingHelper _locationService;
   final ViewCache _viewCache;


### PR DESCRIPTION
**This should only be merged after DI 2.0.1 is available**

This gives the `DirectiveInjector` the same API as what we have for the DI injector.

This change is also **required** because `inject` could not a 1-element List if no factory is provided (this is deprecated)
