### PR TITLE
chore(test-bed): Add fromInjector constructor to TestBed.

### DIFF
--- a/lib/mock/test_bed.dart
+++ b/lib/mock/test_bed.dart
@@ -20,6 +20,10 @@ class TestBed {
 
   TestBed(this.injector, this.directiveInjector, this.rootScope, this.compiler, this._parser, this.expando);
 
+  TestBed.fromInjector(Injector i) :
+    this(i, i.get(DirectiveInjector), i.get(RootScope), i.get(Compiler),
+        i.get(Parser), i.get(Expando));
+
 
   /**
    * Use to compile HTML and activate its directives.


### PR DESCRIPTION
Some clients do not generate static factories for test code, thus
depending on TestBed constructor. The new constructor is basically the
factory method, requiring only injector vs a full set of parameters.

Once clients have been moved to use fromInjector method (or even better
a transformer for test code), we can change the constructor dependencies
in a non-braking way.
