### PR TITLE
feat(directive-injector): introduce getFromParent[byKey] methods on Dire...

### DIFF
--- a/lib/directive/ng_control.dart
+++ b/lib/directive/ng_control.dart
@@ -41,7 +41,7 @@ abstract class NgControl implements AttachAware, DetachAware {
 
   NgControl(NgElement this._element, DirectiveInjector injector,
       Animate this._animate)
-      : _parentControl = injector.parent.getByKey(NG_CONTROL_KEY);
+      : _parentControl = injector.getFromParentByKey(NG_CONTROL_KEY);
 
   @override
   void attach() {

--- a/lib/routing/ng_bind_route.dart
+++ b/lib/routing/ng_bind_route.dart
@@ -38,7 +38,7 @@ class NgBindRoute implements RouteProvider {
   NgBindRoute(this._router, this._injector, NgRoutingHelper _);
 
   /// Returns the parent [RouteProvider].
-  RouteProvider get _parent => _injector.parent.getByKey(ROUTE_PROVIDER_KEY);
+  RouteProvider get _parent => _injector.getFromParentByKey(ROUTE_PROVIDER_KEY);
 
   Route get route => routeName.startsWith('.') ?
       _parent.route.getRoute(routeName.substring(1)) :

--- a/lib/routing/ng_view.dart
+++ b/lib/routing/ng_view.dart
@@ -76,7 +76,7 @@ class NgView implements DetachAware, RouteProvider {
       : _dirInjector = dirInjector,
         _locationService = dirInjector.getByKey(NG_ROUTING_HELPER_KEY)
   {
-    RouteProvider routeProvider = dirInjector.parent.getByKey(NG_VIEW_KEY);
+    RouteProvider routeProvider = dirInjector.getFromParentByKey(NG_VIEW_KEY);
     _route = routeProvider != null ?
         routeProvider.route.newHandle() :
         router.root.newHandle();

--- a/test/core_dom/directive_injector_spec.dart
+++ b/test/core_dom/directive_injector_spec.dart
@@ -2,6 +2,7 @@ library directive_injector_spec;
 
 import '../_specs.dart';
 import 'package:angular/core_dom/directive_injector.dart';
+import 'package:angular/core_dom/static_keys.dart';
 
 void main() {
   describe('DirectiveInjector', () {
@@ -33,7 +34,6 @@ void main() {
       });
 
       it('should return basic types', () {
-        expect(injector.parent is DefaultDirectiveInjector).toBe(true);
         expect(injector.appInjector).toBe(appInjector);
         expect(injector.scope).toBe(scope);
         expect(injector.get(Injector)).toBe(appInjector);
@@ -45,6 +45,16 @@ void main() {
         expect(injector.get(EventHandler)).toBe(eventHandler);
         expect(injector.get(Animate)).toBe(animate);
         expect((injector.get(ElementProbe) as ElementProbe).element).toBe(div);
+      });
+
+      it('should support get from parent methods', () {
+        var newDiv = new DivElement();
+        var childInjector = new DirectiveInjector(
+            injector, appInjector, newDiv, new NodeAttrs(newDiv), eventHandler, scope, animate);
+
+        expect(childInjector.get(Node)).toBe(newDiv);
+        expect(childInjector.getFromParent(Node)).toBe(div);
+        expect(childInjector.getFromParentByKey(NODE_KEY)).toBe(div);
       });
 
       it('should instantiate types', () {


### PR DESCRIPTION
...ctiveInjector

First step towards deprecating injector.parent access.

The reason for the deprecation is that performing injector.parent.get
without keeping track of current injector.appInjector is usually wrong
(since the fallback would be injector.parent.appInjector).
