### PR TITLE
fix(HttpConfig): Remove the optional argument to the default ctor

### DIFF
--- a/lib/core_dom/http.dart
+++ b/lib/core_dom/http.dart
@@ -755,5 +755,7 @@ class Http {
 class HttpConfig {
   final Duration coalesceDuration;
 
-  HttpConfig({this.coalesceDuration});
+  HttpConfig(): coalesceDuration = null;
+
+  HttpConfig.withOptions({this.coalesceDuration});
 }

--- a/lib/core_dom/module_internal.dart
+++ b/lib/core_dom/module_internal.dart
@@ -86,7 +86,7 @@ class CoreDomModule extends Module {
     bind(HttpDefaultHeaders);
     bind(HttpDefaults);
     bind(HttpInterceptors);
-    bind(HttpConfig, toValue: new HttpConfig());
+    bind(HttpConfig);
     bind(Animate);
     bind(ViewCache);
     bind(BrowserCookies);

--- a/test/core_dom/http_spec.dart
+++ b/test/core_dom/http_spec.dart
@@ -1426,8 +1426,8 @@ void main() {
 
     describe('coalesce', () {
       beforeEachModule((Module module) {
-        var coalesceDuration = new Duration(milliseconds: 100);
-        module.bind(HttpConfig, toValue: new HttpConfig(coalesceDuration: coalesceDuration));
+        var duration = new Duration(milliseconds: 100);
+        module.bind(HttpConfig, toValue: new HttpConfig.withOptions(coalesceDuration: duration));
       });
 
       it('should coalesce requests', async((Http http) {


### PR DESCRIPTION
Because this is not currently supported by the Dependency injection.
A new HttpConfig.withOptions() ctor has been added.

This PR fix a warning reported by the analyzer because of the code generated by the DI transformers.
