### PR TITLE
test(css_animate): Remove un-needed code that cause an analyzer warning

### DIFF
--- a/test/animate/css_animate_spec.dart
+++ b/test/animate/css_animate_spec.dart
@@ -92,19 +92,17 @@ _run({bool animationsAllowed}) {
     it('should prevent child animations', async(() {
       _.compile('<div></div>');
       animate.addClass(_.rootElement, 'test');
-      runner.start();
       if (animationsAllowed) {
         expect(_.rootElement).toHaveClass('test-add');
       }
       var spans = es('<span>A</span><span>B</span>');
       animate.insert(spans, _.rootElement);
-      runner.start();
       expect(spans.first).not.toHaveClass('ng-add');
     }));
   });
 }
 
-class MockAnimationLoop extends Mock implements AnimationLoop {
+class MockAnimationLoop implements AnimationLoop {
   bool animationsAllowed;
   num time = 0.0;
 


### PR DESCRIPTION
@codelogic could you please validate this change.

I haven't found a valid for the need to extend `Mock` & call `runner.start()`. 
