### PR TITLE
Fix caching in web platform

### DIFF
--- a/lib/core_dom/web_platform.dart
+++ b/lib/core_dom/web_platform.dart
@@ -95,12 +95,13 @@ class PlatformViewCache implements ViewCache {
   }
 
   async.Future<ViewFactory> fromUrl(String url, DirectiveMap directives) {
-    ViewFactory viewFactory = viewFactoryCache.get(url);
+    String cacheKey = _cacheKeyPrefix + url;
+    ViewFactory viewFactory = viewFactoryCache.get(cacheKey);
     if (viewFactory == null) {
       return http.get(url, cache: templateCache).then((resp) {
-        var viewFactoryFromHttp = fromHtml(resp.responseText, directives);
-        viewFactoryCache.put(url, viewFactoryFromHttp);
-        return viewFactoryFromHttp;
+        ViewFactory factory = fromHtml(resp.responseText, directives);
+        viewFactoryCache.put(cacheKey, factory);
+        return factory;
       });
     }
     return new async.Future.value(viewFactory);


### PR DESCRIPTION
The first commit fix the caching in `fromHtml()`: the `viewFactory`  instances were stored and retrieved under a different key. This made the cache inoperative for cases where shim is needed.

The second commit fix the caching in `fromUrl()`: the `viewFactory` instances were stored under a key that do not depend on the selector name. This would have resulted in getting a wrong shim when:
- two component share a same `templateUrl`,
- a component has multiple different `selector`s .
