### PR TITLE
Clean up export.

### DIFF
--- a/lib/core/annotation.dart
+++ b/lib/core/annotation.dart
@@ -8,7 +8,6 @@ import "dart:html" show ShadowRoot;
 export "package:angular/core/annotation_src.dart" show
     AttachAware,
     DetachAware,
-    ShadowRootAware,
 
     Formatter,
     DirectiveBinder,


### PR DESCRIPTION
ShadowRootAware is defined in annotation.dart and not in annotation_src.dart.
