### PR TITLE
feat(probe): add directive getter and export ElementProbe type.

### DIFF
--- a/lib/core_dom/view_factory.dart
+++ b/lib/core_dom/view_factory.dart
@@ -207,4 +207,6 @@ class ElementProbe {
   final modelExpressions = <String>[];
 
   ElementProbe(this.parent, this.element, this.injector, this.scope);
+
+  dynamic directive(Type type) => injector.get(type);
 }

--- a/lib/introspection.dart
+++ b/lib/introspection.dart
@@ -13,6 +13,8 @@ import 'package:angular/core_dom/module_internal.dart';
 import 'package:angular/core_dom/directive_injector.dart' show DirectiveInjector;
 import 'package:angular/core/static_keys.dart';
 
+export 'package:angular/core_dom/module_internal.dart' show ElementProbe;
+
 
 /**
  * A global write only variable which keeps track of objects attached to the


### PR DESCRIPTION
This brings feature parity to ElementProbe with the deprecated Probe
directive.
