### PR TITLE
feat(TestBed): add whitespace handling to compile

### DIFF
--- a/lib/mock/test_bed.dart
+++ b/lib/mock/test_bed.dart
@@ -63,7 +63,8 @@ class TestBed {
    */
   List<Element> toNodeList(html) {
     var div = new DivElement();
-    div.setInnerHtml(html, treeSanitizer: new NullTreeSanitizer());
+    var sanitizedHtml = _handleWhitespace(html);
+    div.setInnerHtml(sanitizedHtml, treeSanitizer: new NullTreeSanitizer());
     var nodes = [];
     for (var node in div.nodes) {
       nodes.add(node);
@@ -101,4 +102,12 @@ class TestBed {
   }
 
   getScope(Node node) => getProbe(node).scope;
+
+  String _handleWhitespace(html) {
+    return html.split('\n')
+               .map((line) {
+                 var trimmed = line.trim();
+                 return trimmed + (trimmed.isEmpty || trimmed.endsWith('>') ? '' : ' ');})
+               .join();
+  }
 }

--- a/test/mock/test_bed_spec.dart
+++ b/test/mock/test_bed_spec.dart
@@ -27,6 +27,24 @@ void main() {
       expect(directiveInst.destroyed).toBe(true);
     });
 
+    it('should handle whitespace cleanly', () {
+      var root = _.compile('''
+        <div>
+          <h1
+             attr="Hi">
+          </h1>
+        </div>
+      <span  
+       attr2="Bye"
+
+      ></span>
+      ''');
+
+      expect(root).toBeAnInstanceOf(DivElement);
+      expect(_.rootElements[1]).toBeAnInstanceOf(SpanElement);
+      expect(_.rootElements.length).toBe(2);
+    });
+
   });
 }
 


### PR DESCRIPTION
Add whitespace handling to the TestBed’s compile function.

Closes #1262. Previously, strings passed with leading or
trailing whitespace would be compiled incorrectly. Now,
valid HTML with arbitrary whitespace in and surrounding it
can be compiled properly.
