### PR TITLE
chore(pubspec): use perf_api v0.0.9

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -72,7 +72,7 @@ packages:
   perf_api:
     description: perf_api
     source: hosted
-    version: "0.0.8"
+    version: "0.0.9"
   protractor:
     description: protractor
     source: hosted


### PR DESCRIPTION
This fixes a Travis failure with Dart SDK 1.6.0.dev-8.0 that breaks
master.

  Chrome 37.0.2062 (Mac OS X 10.9.4) ERROR
    Internal error: 'package:perf_api/perf_api.dart': error: line 9 pos 29: expression is not a valid compile-time constant
      final Counters counters = new Counters();
