### PR TITLE
Make View Hydration Explicit

### DIFF
--- a/lib/core_dom/element_binder.dart
+++ b/lib/core_dom/element_binder.dart
@@ -190,8 +190,9 @@ class ElementBinder {
     }
   }
 
-  void _link(DirectiveInjector directiveInjector, Scope scope, nodeAttrs) {
+  void hydrate(DirectiveInjector directiveInjector, Scope scope) {
     var s;
+    var nodeAttrs = directiveInjector.get(NodeAttrs);
     for(var i = 0; i < _usableDirectiveRefs.length; i++) {
       DirectiveRef ref = _usableDirectiveRefs[i];
       var key = ref.typeKey;
@@ -254,13 +255,11 @@ class ElementBinder {
     }
   }
 
-  DirectiveInjector bind(View view, Scope scope,
+  DirectiveInjector setUp(View view, Scope scope,
                          DirectiveInjector parentInjector,
                          dom.Node node) {
     var nodeAttrs = node is dom.Element ? new NodeAttrs(node) : null;
-
     var directiveRefs = _usableDirectiveRefs;
-    if (!hasDirectivesOrEvents) return parentInjector;
 
     DirectiveInjector nodeInjector;
     var parentEventHandler = parentInjector == null ?
@@ -294,8 +293,6 @@ class ElementBinder {
       // TODO(misko): pretty sure that clearing Expando is not necessary. Remove?
       scope.on(ScopeEvent.DESTROY).listen((_) => _expando[node] = null);
     }
-
-    _link(nodeInjector, scope, nodeAttrs);
 
     var jsNode;
     List bindAssignableProps = [];

--- a/lib/core_dom/view_factory.dart
+++ b/lib/core_dom/view_factory.dart
@@ -64,8 +64,9 @@ class ViewFactory implements Function {
   }
 
   void _bindTagged(TaggedElementBinder tagged, int elementBinderIndex,
-                   DirectiveInjector rootInjector,
-                   List<DirectiveInjector> elementInjectors, View view, boundNode, Scope scope) {
+      DirectiveInjector rootInjector,
+      List<DirectiveInjector> elementInjectors, View view, boundNode,
+      Scope scope, _Hydrator hydrator) {
     var binder = tagged.binder;
     DirectiveInjector parentInjector =
         tagged.parentBinderOffset == -1 ? rootInjector : elementInjectors[tagged.parentBinderOffset];
@@ -78,7 +79,8 @@ class ViewFactory implements Function {
       if (parentInjector != rootInjector && parentInjector.scope != null) {
         scope = parentInjector.scope;
       }
-      elementInjector = binder.bind(view, scope, parentInjector, boundNode);
+      elementInjector = binder.setUp(view, scope, parentInjector, boundNode);
+      hydrator.addEntry(binder, elementInjector);
     }
     // TODO(misko): Remove this after we remove controllers. No controllers -> 1to1 Scope:View.
     if (elementInjector != rootInjector && elementInjector.scope != null) {
@@ -90,12 +92,14 @@ class ViewFactory implements Function {
       for (var k = 0; k < tagged.textBinders.length; k++) {
         TaggedTextBinder taggedText = tagged.textBinders[k];
         var childNode = boundNode.childNodes[taggedText.offsetIndex];
-        taggedText.binder.bind(view, scope, elementInjector, childNode);
+        final injector = taggedText.binder.setUp(view, scope, elementInjector, childNode);
+        hydrator.addEntry(taggedText.binder, injector);
       }
     }
   }
 
   View _link(View view, Scope scope, List<dom.Node> nodeList, DirectiveInjector rootInjector) {
+    final hydrator = new _Hydrator();
     var elementInjectors = new List<DirectiveInjector>(elementBinders.length);
     var directiveDefsByName = {};
 
@@ -117,7 +121,7 @@ class ViewFactory implements Function {
         if (linkingInfo.containsNgBinding) {
           var tagged = elementBinders[elementBinderIndex];
           _bindTagged(tagged, elementBinderIndex, rootInjector,
-              elementInjectors, view, node, scope);
+              elementInjectors, view, node, scope, hydrator);
           elementBinderIndex++;
         }
 
@@ -126,7 +130,7 @@ class ViewFactory implements Function {
           for (int j = 0; j < elts.length; j++, elementBinderIndex++) {
             TaggedElementBinder tagged = elementBinders[elementBinderIndex];
             _bindTagged(tagged, elementBinderIndex, rootInjector, elementInjectors,
-                        view, elts[j], scope);
+                        view, elts[j], scope, hydrator);
           }
         }
       } else {
@@ -134,7 +138,7 @@ class ViewFactory implements Function {
         assert(tagged.binder != null || tagged.isTopLevel);
         if (tagged.binder != null) {
           _bindTagged(tagged, elementBinderIndex, rootInjector,
-              elementInjectors, view, node, scope);
+              elementInjectors, view, node, scope, hydrator);
         }
         elementBinderIndex++;
       }
@@ -144,10 +148,31 @@ class ViewFactory implements Function {
         nodeList[i] = parentNode.nodes[0];
       }
     }
+    hydrator.hydrate();
     return view;
   }
 }
 
+
+class _Hydrator extends LinkedList<_HydratorEntry> {
+  void hydrate() {
+    forEach((entry) => entry.hydrate());
+  }
+
+  void addEntry(ElementBinder binder, DirectiveInjector injector) {
+    add(new _HydratorEntry(binder, injector));
+  }
+}
+
+class _HydratorEntry extends LinkedListEntry<_HydratorEntry> {
+  final ElementBinder binder;
+  final DirectiveInjector directiveInjector;
+  _HydratorEntry(this.binder, this.directiveInjector);
+
+  void hydrate() {
+    binder.hydrate(directiveInjector, directiveInjector.scope);
+  }
+}
 
 class NodeLinkingInfo {
   /**


### PR DESCRIPTION
This PR separates the creation of directive injectors from the hydration of the view. It is a step to enable view caching.
