### PR TITLE
Revert "[#1164] move `web_components` line to dev_dependencies in the pu...

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,10 +24,10 @@ dependencies:
   intl: '>=0.8.7 <0.12.0'
   perf_api: '>=0.0.8 <0.1.0'
   route_hierarchical: '>=0.4.22 <0.5.0'
+  web_components: '>=0.3.3 <0.4.0'
 dev_dependencies:
   benchmark_harness: '>=1.0.0 <2.0.0'
   guinness: '>=0.1.9 <0.2.0'
   mock: '>=0.10.0 <0.12.0'
   protractor: '0.0.5'
   unittest: '>=0.10.1 <0.12.0'
-  web_components: '>=0.3.3 <0.4.0'


### PR DESCRIPTION
...bspec.yaml"

This reverts commit 51ee50a7d0691f8402196c74be368077606be93a.

I think [the discussion is not closed](https://github.com/angular/angular.dart/pull/1321#issuecomment-52259021) on this topic, easier to discuss here than on a closed PR.

@jbdeboer @vsavkin
