### PR TITLE
fix(web components): Fix tests in IE10

### DIFF
--- a/test/core_dom/web_components_support.js
+++ b/test/core_dom/web_components_support.js
@@ -1,10 +1,18 @@
 /**
- * Used to create Javascript Web Components from Dart tests
+ * Registers Javascript Web Components from Dart tests.
+ *
+ * Per HTML5 spec, the prototype object should inherit from `HTMLELement`.
+ * see http://w3c.github.io/webcomponents/spec/custom/#extensions-to-document-interface-to-register
+ *
+ * Note: __proto__ can not be used as it is not supported in IE10.
  */
 function angularTestsRegisterElement(name, prototype) {
-  // Polymer requires that all prototypes are chained to HTMLElement
-  // https://github.com/Polymer/CustomElements/issues/121
-  prototype.__proto__ = HTMLElement.prototype;
-  prototype.createdCallback = function() {};
-  document.registerElement(name, {prototype: prototype});
+  var proto = Object.create(HTMLElement.prototype);
+  for (var p in prototype) {
+    if (prototype.hasOwnProperty(p)) {
+      proto[p] = prototype[p];
+    }
+  }
+  proto.createdCallback = function() {};
+  document.registerElement(name, {prototype: proto});
 }


### PR DESCRIPTION
@jbdeboer could you please review this PR, I'd like to get this in ASAP as it would allow enabling the tests on IE10.

The [tests pass on IE10](https://travis-ci.org/vicb/angular.dart/builds/33049150) with this update (there is actually a failure in that branch but no more related to wc)

Thanks to @vsavkin for helping me find the root cause of the issue.
