### PR TITLE
refactor(dom): hide all dom access behind a facade

### DIFF
--- a/lib/animate/animation_loop.dart
+++ b/lib/animate/animation_loop.dart
@@ -104,7 +104,7 @@ class AnimationLoop {
 @Injectable()
 class AnimationFrame {
   final dom.Window _wnd;
-  Future<num> get animationFrame => _wnd.animationFrame;
+  Future<num> get animationFrame => dom.animationFrame(_wnd);
 
   AnimationFrame(this._wnd);
 }

--- a/lib/animate/animation_optimizer.dart
+++ b/lib/animate/animation_optimizer.dart
@@ -120,7 +120,7 @@ class AnimationOptimizer {
     // default, we assume that we can run.
     bool autoDecision = true;
 
-    node = node.parentNode;
+    node = dom.parentNode(node);
     while (node != null) {
       // Does this node give us animation information about our children?
       alwaysAnimate = _alwaysAnimateChildren[node];
@@ -139,7 +139,7 @@ class AnimationOptimizer {
       }
 
       // If we hit a null parent, try to break out of shadow dom.
-      if (node.parentNode == null) {
+      if (dom.parentNode(node) == null) {
         var probe = _findElementProbe(node);
         if (probe != null && probe.parent != null) {
           // Escape shadow dom!
@@ -150,7 +150,7 @@ class AnimationOptimizer {
           return autoDecision;
         }
       } else {
-        node = node.parentNode;
+        node = dom.parentNode(node);
       }
     }
 
@@ -163,7 +163,7 @@ class AnimationOptimizer {
       if (_expando[node] != null) {
         return _expando[node];
       }
-      node = node.parentNode;
+      node = dom.parentNode(node);
     }
     return null;
   }

--- a/lib/animate/css_animate.dart
+++ b/lib/animate/css_animate.dart
@@ -32,7 +32,7 @@ class CssAnimate implements Animate {
 
   Animation addClass(dom.Element element, String cssClass) {
     if (!_optimizer.shouldAnimate(element)) {
-      element.classes.add(cssClass);
+      dom.addClass(element, cssClass);
       return _noOp;
     }
 
@@ -43,7 +43,7 @@ class CssAnimate implements Animate {
 
   Animation removeClass(dom.Element element, String cssClass) {
     if (!_optimizer.shouldAnimate(element)) {
-      element.classes.remove(cssClass);
+      dom.removeClass(element, cssClass);
       return _noOp;
     }
 
@@ -74,7 +74,7 @@ class CssAnimate implements Animate {
     });
 
     var result = _animationFromList(animations)..onCompleted.then((result) {
-      if (result.isCompleted) nodes.toList().forEach((n) => n.remove());
+      if (result.isCompleted) nodes.toList().forEach(dom.removeNode);
     });
 
     return result;

--- a/lib/animate/css_animation.dart
+++ b/lib/animate/css_animation.dart
@@ -47,15 +47,16 @@ class CssAnimation extends LoopedAnimation {
   {
     if (_optimizer != null) _optimizer.track(this, element);
     if (_animationMap != null) _animationMap.track(this);
-    element.classes.add(eventClass);
-    if (addAtStart != null) element.classes.add(addAtStart);
-    if (removeAtStart != null) element.classes.remove(removeAtStart);
+
+    dom.addClass(element, eventClass);
+    if (addAtStart != null) dom.addClass(element, addAtStart);
+    if (removeAtStart != null) dom.removeClass(element, removeAtStart);
   }
 
   void read(num timeInMs) {
     if (_active && _startTime == null) {
       _startTime = timeInMs;
-      var style = element.getComputedStyle();
+      var style = dom.getComputedStyle(element);
       _isDisplayNone = style.display == "none";
       _duration = util.computeLongestTransition(style);
       if (_duration > 0.0) {
@@ -85,10 +86,10 @@ class CssAnimation extends LoopedAnimation {
       // will not run their enter animation.
 
       if (_isDisplayNone && removeAtEnd != null) {
-        element.classes.remove(removeAtEnd);
+        dom.removeClass(element, removeAtEnd);
       }
 
-      element.classes.add(activeClass);
+      dom.addClass(element, activeClass);
       _started = true;
     }
 
@@ -99,8 +100,8 @@ class CssAnimation extends LoopedAnimation {
   void cancel() {
     if (_active) {
       _detach();
-      if (addAtStart != null) element.classes.remove(addAtStart);
-      if (removeAtStart != null) element.classes.add(removeAtStart);
+      if (addAtStart != null) dom.removeClass(element, addAtStart);
+      if (removeAtStart != null) dom.addClass(element, removeAtStart);
       if (_completer != null) _completer.complete(AnimationResult.CANCELED);
     }
   }
@@ -114,8 +115,8 @@ class CssAnimation extends LoopedAnimation {
   void _complete(AnimationResult result) {
     if (_active) {
       _detach();
-      if (addAtEnd != null) element.classes.add(addAtEnd);
-      if (removeAtEnd != null) element.classes.remove(removeAtEnd);
+      if (addAtEnd != null) dom.addClass(element, addAtEnd);
+      if (removeAtEnd != null) dom.removeClass(element, removeAtEnd);
       _completer.complete(result);
     }
   }
@@ -127,6 +128,8 @@ class CssAnimation extends LoopedAnimation {
     if (_animationMap != null) _animationMap.forget(this);
     if (_optimizer != null) _optimizer.forget(this);
 
-    element.classes..remove(eventClass)..remove(activeClass);
+
+    dom.removeClass(element, eventClass);
+    dom.removeClass(element, activeClass);
   }
 }

--- a/lib/animate/module.dart
+++ b/lib/animate/module.dart
@@ -99,8 +99,7 @@
 library angular.animate;
 
 import 'dart:async';
-import 'dart:html' as dom;
-
+import 'package:angular/dom/dom.dart' as dom;
 import 'package:angular/core/annotation.dart';
 import 'package:angular/core/module_internal.dart';
 import 'package:angular/core_dom/module_internal.dart';

--- a/lib/application.dart
+++ b/lib/application.dart
@@ -67,11 +67,11 @@
  */
 library angular.app;
 
-import 'dart:html' as dom;
 import 'dart:js' show context;
 
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:di/di.dart';
+import 'package:angular/dom/dom.dart' as dom;
 import 'package:angular/angular.dart';
 import 'package:angular/perf/module.dart';
 import 'package:angular/cache/module.dart';

--- a/lib/application_factory.dart
+++ b/lib/application_factory.dart
@@ -16,7 +16,6 @@ import 'package:angular/change_detection/change_detection.dart';
 import 'package:angular/change_detection/dirty_checking_change_detector_dynamic.dart';
 import 'package:angular/core/registry_dynamic.dart';
 import 'package:angular/core/parser/dynamic_closure_map.dart';
-import 'dart:html';
 
 /**
  * If you are writing code accessed from Angular expressions, you must include

--- a/lib/core/annotation.dart
+++ b/lib/core/annotation.dart
@@ -3,7 +3,7 @@
  */
 library angular.core.annotation;
 
-import "dart:html" show ShadowRoot;
+import "package:angular/dom/dom.dart" show ShadowRoot;
 
 export "package:angular/core/annotation_src.dart" show
     AttachAware,

--- a/lib/core_dom/animation.dart
+++ b/lib/core_dom/animation.dart
@@ -20,7 +20,7 @@ class Animate {
    * defined animations.
    */
   Animation addClass(dom.Element element, String cssClass) {
-    element.classes.add(cssClass);
+    dom.addClass(element, cssClass);
     return new NoOpAnimation();
   }
 
@@ -29,7 +29,7 @@ class Animate {
     * defined animations.
     */
   Animation removeClass(dom.Element element, String cssClass) {
-    element.classes.remove(cssClass);
+    dom.removeClass(element, cssClass);
     return new NoOpAnimation();
   }
 

--- a/lib/core_dom/common.dart
+++ b/lib/core_dom/common.dart
@@ -4,7 +4,7 @@ List<dom.Node> cloneElements(List<dom.Node> elements) {
   int length = elements.length;
   var clones = new List(length);
   for(var i=0; i < length; i++) {
-    clones[i] = elements[i].clone(true);
+    clones[i] = dom.clone(elements[i]);
   }
   return clones;
 }
@@ -37,7 +37,7 @@ class DirectiveRef {
 
   String toString() {
     var html = element is dom.Element
-        ? (element as dom.Element).outerHtml
+        ? dom.outerHtml(element)
         : element.nodeValue;
     return '{ element: $html, selector: ${annotation.selector}, value: $value, '
            'ast: ${valueAST == null ? 'null' : '$valueAST'}, '

--- a/lib/core_dom/directive.dart
+++ b/lib/core_dom/directive.dart
@@ -22,16 +22,16 @@ class NodeAttrs {
 
   NodeAttrs(this.element);
 
-  operator [](String attrName) => element.attributes[attrName];
+  operator [](String attrName) => dom.getAttribute(element, attrName);
 
   void operator []=(String attrName, String value) {
     if (_mustacheAttrs.containsKey(attrName)) {
       _mustacheAttrs[attrName].isComputed = true;
     }
     if (value == null) {
-      element.attributes.remove(attrName);
+      dom.removeAttribute(element, attrName);
     } else {
-      element.attributes[attrName] = value;
+      dom.setAttribute(element, attrName, value);
     }
 
     if (_observers != null && _observers.containsKey(attrName)) {
@@ -62,12 +62,12 @@ class NodeAttrs {
   }
 
   void forEach(void f(String k, String v)) {
-    element.attributes.forEach(f);
+    dom.attributes(element).forEach(f);
   }
 
-  bool containsKey(String attrName) => element.attributes.containsKey(attrName);
+  bool containsKey(String attrName) => dom.attributes(element).containsKey(attrName);
 
-  Iterable<String> get keys => element.attributes.keys;
+  Iterable<String> get keys => dom.attributes(element).keys;
 
   /**
    * Registers a listener to be called when the attribute [attrName] becomes

--- a/lib/core_dom/directive_injector.dart
+++ b/lib/core_dom/directive_injector.dart
@@ -1,11 +1,12 @@
 library angular.node_injector;
 
-import 'dart:html' show Node, Element, ShadowRoot;
+
 import 'dart:profiler';
 
 import 'package:di/di.dart';
 import 'package:di/annotations.dart';
 import 'package:di/src/module.dart' show DEFAULT_VALUE, Binding;
+import 'package:angular/dom/dom.dart' as dom;
 import 'package:angular/core/static_keys.dart';
 import 'package:angular/core_dom/static_keys.dart';
 
@@ -22,7 +23,7 @@ final DIRECTIVE_INJECTOR_KEY = new Key(DirectiveInjector);
 final COMPONENT_DIRECTIVE_INJECTOR_KEY = new Key(ComponentDirectiveInjector);
 final CONTENT_PORT_KEY = new Key(ContentPort);
 final TEMPLATE_LOADER_KEY = new Key(TemplateLoader);
-final SHADOW_ROOT_KEY = new Key(ShadowRoot);
+final SHADOW_ROOT_KEY = new Key(dom.ShadowRoot);
 
 final num MAX_DEPTH = 1 << 30;
 
@@ -105,7 +106,7 @@ class DirectiveInjector implements DirectiveBinder {
   
   final DirectiveInjector _parent;
   final Injector _appInjector;
-  final Node _node;
+  final dom.Node _node;
   final NodeAttrs _nodeAttrs;
   final Animate _animate;
   final EventHandler _eventHandler;
@@ -373,7 +374,7 @@ class TemplateDirectiveInjector extends DirectiveInjector {
   BoundViewFactory _boundViewFactory;
 
   TemplateDirectiveInjector(DirectiveInjector parent, Injector appInjector,
-                       Node node, NodeAttrs nodeAttrs, EventHandler eventHandler,
+                       dom.Node node, NodeAttrs nodeAttrs, EventHandler eventHandler,
                        Scope scope, Animate animate, this._viewFactory)
     : super(parent, appInjector, node, nodeAttrs, eventHandler, scope, animate);
 
@@ -394,7 +395,7 @@ class TemplateDirectiveInjector extends DirectiveInjector {
 class ComponentDirectiveInjector extends DirectiveInjector {
 
   final TemplateLoader _templateLoader;
-  final ShadowRoot _shadowRoot;
+  final dom.ShadowRoot _shadowRoot;
   final ContentPort _contentPort;
 
   ComponentDirectiveInjector(DirectiveInjector parent, Injector appInjector,

--- a/lib/core_dom/dom_util.dart
+++ b/lib/core_dom/dom_util.dart
@@ -1,6 +1,6 @@
 library angular.dom.util;
 
-import 'dart:html' as dom;
+import 'package:angular/dom/dom.dart' as dom;
 
 Iterable<dom.Element> getElements(Iterable<dom.Node> nodes) =>
     nodes.where((el) => el.nodeType == dom.Node.ELEMENT_NODE);
@@ -13,23 +13,23 @@ void domRemove(List<dom.Node> nodes) {
     dom.Node current = nodes[j];
     dom.Node next = j + 1 < nodes.length ? nodes[j + 1] : null;
 
-    while (next != null && current.nextNode != next) {
-      current.nextNode.remove();
+    while (next != null && dom.nextNode(current) != next) {
+      dom.removeNode(dom.nextNode(current));
     }
-    nodes[j].remove();
+    dom.removeNode(nodes[j]);
   }
 }
 
 void domInsert(Iterable<dom.Node> nodes, dom.Node parent,
                 { dom.Node insertBefore }) {
-  parent.insertAllBefore(nodes, insertBefore);
+  dom.insertAllBefore(parent, nodes, insertBefore);
 }
 
 void domMove(Iterable<dom.Node> nodes, dom.Node parent,
               { dom.Node insertBefore }) {
   nodes.forEach((n) {
-    if (n.parentNode == null) n.remove();
-    parent.insertBefore(n, insertBefore);
+    if (dom.parentNode(n) == null) dom.removeNode(n);
+    dom.insertBefore(parent, n, insertBefore);
   });
 }
 
@@ -42,9 +42,9 @@ List<dom.Node> allNodesBetween(List<dom.Node> nodes) {
     dom.Node current = nodes[j];
     dom.Node next = j + 1 < nodes.length ? nodes[j + 1] : null;
 
-    while (next != null && current.nextNode != next) {
-      result.add(current.nextNode);
-      current = current.nextNode;
+    while (next != null && dom.nextNode(current) != next) {
+      result.add(dom.nextNode(current));
+      current = dom.nextNode(current);
     }
     result.add(nodes[j]);
   }

--- a/lib/core_dom/element_binder_builder.dart
+++ b/lib/core_dom/element_binder_builder.dart
@@ -105,7 +105,7 @@ class ElementBinderBuilder {
         // Look up the value of attrName and compute an AST
         AST ast;
         if (mode != '@' && mode != '&') {
-          var value = attrName == "." ? ref.value : (ref.element as dom.Element).attributes[attrName];
+          var value = attrName == "." ? ref.value : dom.getAttribute(ref.element, attrName);
           if (value == null || value.isEmpty) { value = "''"; }
           ast = _factory.astParser(value, formatters: _formatters);
         }

--- a/lib/core_dom/event_handler.dart
+++ b/lib/core_dom/event_handler.dart
@@ -52,7 +52,7 @@ class EventHandler {
     while (element != null && element != _rootNode) {
       var expression;
       if (element is dom.Element)
-        expression = (element as dom.Element).attributes[eventNameToAttrName(event.type)];
+        expression = dom.getAttribute(element, eventNameToAttrName(event.type));
       if (expression != null) {
         try {
           var scope = _getScope(element);
@@ -61,18 +61,18 @@ class EventHandler {
           _exceptionHandler(e, s);
         }
       }
-      element = element.parentNode;
+      element = dom.parentNode(element);
     }
   }
 
   Scope _getScope(dom.Node element) {
     // var topElement = (rootNode is dom.ShadowRoot) ? rootNode.parentNode : rootNode;
-    while (element != _rootNode.parentNode) {
+    while (element != dom.parentNode(_rootNode)) {
       ElementProbe probe = _expando[element];
       if (probe != null) {
         return probe.scope;
       }
-      element = element.parentNode;
+      element = dom.parentNode(element);
     }
     return null;
   }

--- a/lib/core_dom/module_internal.dart
+++ b/lib/core_dom/module_internal.dart
@@ -2,7 +2,6 @@ library angular.core.dom_internal;
 
 import 'dart:async' as async;
 import 'dart:convert' show JSON;
-import 'dart:html' as dom;
 import 'dart:js' as js;
 
 import 'package:di/di.dart';
@@ -11,6 +10,7 @@ import 'package:perf_api/perf_api.dart';
 
 import 'package:angular/cache/module.dart';
 
+import 'package:angular/dom/dom.dart' as dom;
 import 'package:angular/core/annotation.dart';
 import 'package:angular/core/module_internal.dart';
 import 'package:angular/core/parser/parser.dart';

--- a/lib/core_dom/mustache.dart
+++ b/lib/core_dom/mustache.dart
@@ -12,7 +12,7 @@ class TextMustache {
   }
 
   void _updateMarkup(text, previousText) {
-    _element.text = text;
+    dom.setText(_element, text);
   }
 }
 

--- a/lib/core_dom/ng_element.dart
+++ b/lib/core_dom/ng_element.dart
@@ -57,9 +57,9 @@ class NgElement {
 
     _attributesToUpdate.forEach((String attrName, value) {
       if (value == _TO_BE_REMOVED) {
-        node.attributes.remove(attrName);
+        dom.removeAttribute(node, attrName);
       } else {
-        node.attributes[attrName] = value;
+        dom.setAttribute(node, attrName, value);
       }
     });
     _attributesToUpdate.clear();

--- a/lib/core_dom/node_cursor.dart
+++ b/lib/core_dom/node_cursor.dart
@@ -12,7 +12,7 @@ class NodeCursor {
   dom.Node get current => index < elements.length ? elements[index] : null;
 
   bool descend() {
-    var childNodes = elements[index].nodes;
+    var childNodes = dom.nodes(elements[index]);
     var hasChildren = childNodes.isNotEmpty;
 
     if (hasChildren) {

--- a/lib/core_dom/selector.dart
+++ b/lib/core_dom/selector.dart
@@ -73,21 +73,21 @@ class DirectiveSelector {
     String nodeName = element.tagName.toLowerCase();
 
     // Set default attribute
-    if (nodeName == 'input' && !element.attributes.containsKey('type')) {
-      element.attributes['type'] = 'text';
+    if (nodeName == 'input' && !dom.attributes(element).containsKey('type')) {
+      dom.setAttribute(element, 'type', 'text');
     }
 
     // Select node
     partialSelection = elementSelector.selectNode(builder, partialSelection, element, nodeName);
 
     // Select .name
-    for (var name in element.classes) {
+    for (var name in dom.classes(element)) {
       classes.add(name);
       partialSelection = elementSelector.selectClass(builder, partialSelection, element, name);
     }
 
     // Select [attributes]
-    element.attributes.forEach((attrName, value) {
+    dom.attributes(element).forEach((attrName, value) {
 
       if (attrName.startsWith("on-")) {
         builder.onEvents[attrName] = value;

--- a/lib/core_dom/shadow_dom_component_factory.dart
+++ b/lib/core_dom/shadow_dom_component_factory.dart
@@ -100,10 +100,9 @@ class BoundShadowDomComponentFactory implements BoundComponentFactory {
           }
 
           // If a css rewriter is installed, run the css through a rewriter
-          var styleElement = new dom.StyleElement()
-            ..appendText(componentCssRewriter(css, selector: _tag,
-          cssUrl: cssUrl));
-
+          var styleElement = new dom.StyleElement();
+          dom.appendText(styleElement, componentCssRewriter(css, selector: _tag, cssUrl: cssUrl));
+            
           // ensure there are no invalid tags or modifications
           treeSanitizer.sanitizeTree(styleElement);
 

--- a/lib/core_dom/static_keys.dart
+++ b/lib/core_dom/static_keys.dart
@@ -1,8 +1,9 @@
 library angular.core_dom.static_keys;
 
-import 'dart:html' as dom;
 import 'package:di/di.dart';
 import 'package:angular/cache/module.dart';
+import 'package:angular/dom/dom.dart' as dom;
+import 'package:angular/core/static_keys.dart';
 import 'package:angular/core_dom/module_internal.dart';
 
 export 'package:angular/directive/static_keys.dart' show NG_BASE_CSS_KEY;

--- a/lib/core_dom/transcluding_component_factory.dart
+++ b/lib/core_dom/transcluding_component_factory.dart
@@ -26,8 +26,8 @@ class ContentPort {
   ContentPort(this._element);
 
   void pullNodes() {
-    _childNodes.addAll(_element.nodes);
-    _element.nodes = [];
+    _childNodes.addAll(dom.nodes(_element));
+    dom.setNodes(_element, []);
   }
 
   content(dom.Element elt) {
@@ -36,13 +36,13 @@ class ContentPort {
 
     if (_childNodes.isNotEmpty) {
       beginComment = new dom.Comment("content $hash");
-      elt.parent.insertBefore(beginComment, elt);
-      elt.parent.insertAllBefore(_childNodes, elt);
-      elt.parent.insertBefore(new dom.Comment("end-content $hash"), elt);
+      dom.insertBefore(dom.parentNode(elt), beginComment, elt);
+      dom.insertAllBefore(dom.parentNode(elt), _childNodes, elt);
+      dom.insertBefore(dom.parentNode(elt), new dom.Comment("end-content $hash"), elt);
       _childNodes = [];
     }
 
-    elt.remove();
+    dom.removeNode(elt);
     return beginComment;
   }
 

--- a/lib/core_dom/view.dart
+++ b/lib/core_dom/view.dart
@@ -41,7 +41,7 @@ class ViewPort {
     scope.rootScope.domWrite(() {
       dom.Node previousNode = _lastNode(insertAfter);
       _viewsInsertAfter(view, insertAfter);
-      _animate.insert(view.nodes, placeholder.parentNode, insertBefore: previousNode.nextNode);
+      _animate.insert(view.nodes, dom.parentNode(placeholder), insertBefore: dom.nextNode(previousNode));
     });
     return view;
   }
@@ -60,7 +60,7 @@ class ViewPort {
     _views.remove(view);
     _viewsInsertAfter(view, moveAfter);
     scope.rootScope.domWrite(() {
-      _animate.move(view.nodes, placeholder.parentNode, insertBefore: previousNode.nextNode);
+      _animate.move(view.nodes, dom.parentNode(placeholder), insertBefore: dom.nextNode(previousNode));
     });
     return view;
   }

--- a/lib/core_dom/view_factory.dart
+++ b/lib/core_dom/view_factory.dart
@@ -33,11 +33,11 @@ class ViewFactory implements Function {
     if (traceEnabled) {
       _debugHtml = templateNodes.map((dom.Node e) {
         if (e is dom.Element) {
-          return (e as dom.Element).outerHtml;
+          return dom.outerHtml(e);
         } else if (e is dom.Comment) {
-          return '<!--${(e as dom.Comment).text}-->';
+          return '<!--${dom.text(e)}-->';
         } else {
-          return e.text;
+          return dom.text(e);
         }
       }).toList().join('');
     }
@@ -122,7 +122,7 @@ class ViewFactory implements Function {
         }
 
         if (linkingInfo.ngBindingChildren) {
-          var elts = (node as dom.Element).querySelectorAll('.ng-binding');
+          var elts = dom.querySelectorAll(node, '.ng-binding');
           for (int j = 0; j < elts.length; j++, elementBinderIndex++) {
             TaggedElementBinder tagged = elementBinders[elementBinderIndex];
             _bindTagged(tagged, elementBinderIndex, rootInjector, elementInjectors,
@@ -183,9 +183,9 @@ computeNodeLinkingInfos(List<dom.Node> nodeList) {
     bool isElement = node.nodeType == dom.Node.ELEMENT_NODE;
 
     list[i] = new NodeLinkingInfo(
-        isElement && (node as dom.Element).classes.contains('ng-binding'),
+        isElement && dom.classes(node).contains('ng-binding'),
         isElement,
-        isElement && (node as dom.Element).querySelectorAll('.ng-binding').length > 0);
+        isElement && dom.querySelectorAll(node, '.ng-binding').length > 0);
   }
   return list;
 }
@@ -254,7 +254,7 @@ String _html(obj) {
     return (obj as List).map((e) => _html(e)).join();
   }
   if (obj is dom.Element) {
-    var text = (obj as dom.Element).outerHtml;
+    var text = dom.outerHtml(obj);
     return text.substring(0, text.indexOf('>') + 1);
   }
   return obj.nodeName;

--- a/lib/core_dom/web_platform.dart
+++ b/lib/core_dom/web_platform.dart
@@ -42,7 +42,7 @@ class WebPlatform {
       //
       // TODO Remove the try-catch once https://github.com/angular/angular.dart/issues/1189 is fixed.
       try {
-        root.querySelectorAll("*").forEach((n) => n.attributes[selector] = "");
+        dom.querySelectorAll(root, "*").forEach((dom.Element n) => dom.setAttribute(n, selector, ""));
       } catch (e, s) {
         print("WARNING: Failed to set up Shadow DOM shim for $selector.\n$e\n$s");
       }

--- a/lib/directive/a_href.dart
+++ b/lib/directive/a_href.dart
@@ -16,10 +16,10 @@ class AHref {
   final dom.Element element;
 
   AHref(this.element, VmTurnZone zone) {
-    if (element.attributes["href"] == "") {
+    if (dom.getAttribute(element, "href") == "") {
       zone.runOutsideAngular(() {
         element.onClick.listen((event) {
-          if (element.attributes["href"] == "") {
+          if (dom.getAttribute(element, "href") == "") {
             event.preventDefault();
           }
         });

--- a/lib/directive/module.dart
+++ b/lib/directive/module.dart
@@ -17,9 +17,9 @@
 library angular.directive;
 
 import 'package:di/di.dart';
-import 'dart:html' as dom;
 import 'dart:async' as async;
 import 'package:intl/intl.dart';
+import 'package:angular/dom/dom.dart' as dom;
 import 'package:angular/core/annotation.dart';
 import 'package:angular/core/module_internal.dart';
 import 'package:angular/core/parser/parser.dart';

--- a/lib/directive/ng_bind.dart
+++ b/lib/directive/ng_bind.dart
@@ -23,9 +23,9 @@ class NgBind {
   NgBind(this.element, ElementProbe probe) {
     // TODO(chirayu): Generalize this.
     if (probe != null) {
-      probe.bindingExpressions.add(element.attributes['ng-bind']);
+      probe.bindingExpressions.add(dom.getAttribute(element, 'ng-bind'));
     }
   }
 
-  set value(value) => element.text = value == null ? '' : value.toString();
+  set value(value) => dom.setText(element, value == null ? '' : value.toString());
 }

--- a/lib/directive/ng_bind_html.dart
+++ b/lib/directive/ng_bind_html.dart
@@ -25,6 +25,6 @@ class NgBindHtml {
    * The result of this expression is inserted into the containing element in the DOM according to the
    * rules specified in the documentation for the class.
    */
-  void set value(value) => element.setInnerHtml(
+  void set value(value) => dom.setInnerHtml(element,
       value == null ? '' : value.toString(), validator: validator);
 }

--- a/lib/directive/ng_bind_template.dart
+++ b/lib/directive/ng_bind_template.dart
@@ -18,6 +18,6 @@ class NgBindTemplate {
   NgBindTemplate(this.element);
 
   void set bind(value) {
-    element.text = value;
+    dom.setText(element, value);
   }
 }

--- a/lib/directive/ng_cloak.dart
+++ b/lib/directive/ng_cloak.dart
@@ -34,7 +34,7 @@ part of angular.directive;
 @Decorator(selector: '.ng-cloak')
 class NgCloak {
   NgCloak(dom.Element element, Animate animate) {
-    element.attributes.remove('ng-cloak');
+    dom.removeAttribute(element, 'ng-cloak');
     animate.removeClass(element, 'ng-cloak');
   }
 }

--- a/lib/directive/ng_form.dart
+++ b/lib/directive/ng_form.dart
@@ -37,7 +37,7 @@ class NgForm extends NgControl {
   NgForm(this._scope, NgElement element, DirectiveInjector injector, Animate animate) :
     super(element, injector, animate) {
 
-    if (!element.node.attributes.containsKey('action')) {
+    if (!dom.attributes(element.node).containsKey('action')) {
       element.node.onSubmit.listen((event) {
         event.preventDefault();
         onSubmit(valid == true);

--- a/lib/directive/ng_include.dart
+++ b/lib/directive/ng_include.dart
@@ -37,7 +37,7 @@ class NgInclude {
 
     _view.nodes.forEach((node) => node.remove);
     _scope.destroy();
-    element.innerHtml = '';
+    dom.setInnerHtml(element, '');
 
     _view = null;
     _scope = null;
@@ -48,7 +48,7 @@ class NgInclude {
     _scope = scope.createChild(new PrototypeMap(scope.context));
     _view = viewFactory(_scope, directiveInjector);
 
-    _view.nodes.forEach((node) => element.append(node));
+    _view.nodes.forEach((node) => dom.append(element, node));
   }
 
 

--- a/lib/directive/ng_model.dart
+++ b/lib/directive/ng_model.dart
@@ -314,12 +314,12 @@ class InputCheckbox {
                 this.scope, this.ngTrueValue, this.ngFalseValue, this.ngModelOptions) {
     ngModel.render = (value) {
       scope.rootScope.domWrite(() {
-        inputElement.checked = ngTrueValue.isValue(value);
+        dom.setChecked(inputElement, ngTrueValue.isValue(value));
       });
     };
     inputElement
         ..onChange.listen((_) => ngModelOptions.executeChangeFunc(() {
-          ngModel.viewValue = inputElement.checked ? ngTrueValue.value : ngFalseValue.value;
+          ngModel.viewValue = dom.isChecked(inputElement) ? ngTrueValue.value : ngFalseValue.value;
         }))
         ..onBlur.listen((_) => ngModelOptions.executeBlurFunc(() {
           ngModel.markAsTouched();
@@ -424,7 +424,7 @@ class InputNumberLike {
 
 
   // We can't use [inputElement.valueAsNumber] due to http://dartbug.com/15788
-  num get typedValue => num.parse(inputElement.value, (v) => double.NAN);
+  num get typedValue => num.parse(dom.value(inputElement), (v) => double.NAN);
 
   void set typedValue(num value) {
     // [chalin, 2014-02-16] This post
@@ -433,10 +433,10 @@ class InputNumberLike {
     // it does not. [TODO: put BUG/ISSUE number here].  We implement a
     // workaround by setting `value`. Clean-up once the bug is fixed.
     if (value == null) {
-      inputElement.value = null;
+      dom.setValue(inputElement, null);
     } else {
       // We can't use inputElement.valueAsNumber due to http://dartbug.com/15788
-      inputElement.value = "$value";
+      dom.setValue(inputElement, "$value");
     }
   }
 
@@ -511,8 +511,8 @@ class NgBindTypeForDateLike {
   dynamic get inputTypedValue {
     switch (idlAttrKind) {
       case DATE:   return inputValueAsDate;
-      case NUMBER: return inputElement.valueAsNumber;
-      default:     return inputElement.value;
+      case NUMBER: return dom.valueAsNumber(inputElement);
+      default:     return dom.value(inputElement);
     }
   }
 
@@ -520,9 +520,9 @@ class NgBindTypeForDateLike {
     if (inputValue is DateTime) {
       inputValueAsDate = inputValue;
     } else if (inputValue is num) {
-      inputElement.valueAsNumber = inputValue;
+      dom.setValueAsNumber(inputElement, inputValue);
     } else {
-      inputElement.value = inputValue;
+      dom.setValue(inputElement, inputValue);
     }
   }
 
@@ -532,7 +532,7 @@ class NgBindTypeForDateLike {
     // Wrap in try-catch due to
     // https://code.google.com/p/dart/issues/detail?id=17625
     try {
-      dt = inputElement.valueAsDate;
+      dt = dom.valueAsDate(inputElement);
     } catch (e) {
       dt = null;
     }
@@ -542,7 +542,7 @@ class NgBindTypeForDateLike {
   /// Set input's `valueAsDate`. Argument is normalized to UTC if necessary
   /// (per HTML standard).
   void set inputValueAsDate(DateTime dt) {
-    inputElement.valueAsDate = (dt != null && !dt.isUtc) ? dt.toUtc() : dt;
+    dom.setValueAsDate(inputElement, (dt != null && !dt.isUtc) ? dt.toUtc() : dt);
   }
 }
 
@@ -799,12 +799,12 @@ class InputRadio {
     }
     ngModel.render = (value) {
       scope.rootScope.domWrite(() {
-        radioButtonElement.checked = (value == ngValue.value);
+        dom.setChecked(radioButtonElement, value == ngValue.value);
       });
     };
     radioButtonElement
         ..onClick.listen((_) {
-          if (radioButtonElement.checked) ngModel.viewValue = ngValue.value;
+          if (dom.isChecked(radioButtonElement)) ngModel.viewValue = ngValue.value;
         })
         ..onBlur.listen((event) {
           ngModel.markAsTouched();

--- a/lib/directive/ng_model_select.dart
+++ b/lib/directive/ng_model_select.dart
@@ -36,8 +36,8 @@ class InputSelect implements AttachAware {
 
   InputSelect(dom.Element this._selectElement, this._attrs, this._model,
               this._scope) {
-    _unknownOption.value = '?';
-    _nullOption = _selectElement.querySelectorAll('option')
+    dom.setValue(_unknownOption, '?');
+    _nullOption = dom.querySelectorAll(_selectElement, 'option')
         .firstWhere((o) => o.value == '', orElse: () => null);
   }
 
@@ -138,7 +138,7 @@ class _SelectMode {
   onModelChange(value) {}
   destroy() {}
 
-  get _options => select.querySelectorAll('option');
+  get _options => dom.querySelectorAll(select, 'option');
   _forEachOption(fn, [quitOnReturn = false]) {
     for (var i = 0; i < _options.length; i++) {
       var retValue = fn(_options[i], i);
@@ -193,13 +193,13 @@ class _SingleSelectMode extends _SelectMode {
 
     if (!found) {
       if (!_unknownOptionActive) {
-        select.insertBefore(_unknownOption, select.firstChild);
-        _unknownOption.selected = true;
+        dom.insertBefore(select, _unknownOption, dom.firstChild(select));
+        dom.setSelected(_unknownOption, true);
         _unknownOptionActive = true;
       }
     } else {
       if (_unknownOptionActive) {
-        _unknownOption.remove();
+        dom.removeNode(_unknownOption);
         _unknownOptionActive = false;
       }
     }

--- a/lib/directive/ng_pluralize.dart
+++ b/lib/directive/ng_pluralize.dart
@@ -112,17 +112,17 @@ class NgPluralize {
   };
 
   NgPluralize(this._scope, this._element, this._interpolate, this._formatters) {
-    var attrs = _element.attributes;
+    var attrs = dom.attributes(_element);
     final whens = attrs['when'] == null
         ? <String, String>{}
         : _scope.eval(attrs['when']);
     _offset = attrs['offset'] == null ? 0 : int.parse(attrs['offset']);
 
-    _element.attributes.keys.where((k) => IS_WHEN.hasMatch(k)).forEach((k) {
+    dom.attributes(_element).keys.where((k) => IS_WHEN.hasMatch(k)).forEach((k) {
       var ruleName = k
           .replaceFirst(new RegExp('^when-'), '')
           .replaceFirst(new RegExp('^minus-'), '-');
-      whens[ruleName] = _element.attributes[k];
+      whens[ruleName] = dom.getAttribute(_element, k);
     });
 
     if (whens['other'] == null) {
@@ -145,7 +145,7 @@ class NgPluralize {
       try {
         value = num.parse(value);
       } catch(e) {
-        _element.text = '';
+        dom.setText(_element, '');
         return;
       }
     }
@@ -173,6 +173,6 @@ class NgPluralize {
   }
 
   void _updateMarkup(text, previousText) {
-    if (text != previousText) _element.text = text;
+    if (text != previousText) dom.setText(_element, text);
   }
 }

--- a/lib/directive/ng_style.dart
+++ b/lib/directive/ng_style.dart
@@ -34,9 +34,9 @@ class NgStyle {
 
   _onStyleChange(MapChangeRecord mapChangeRecord, _) {
     if (mapChangeRecord != null) {
-      dom.CssStyleDeclaration css = _element.style;
+      dom.CssStyleDeclaration css = dom.style(_element);
       fn(MapKeyValue m) =>
-          css.setProperty(m.key, m.currentValue == null ? '' : m.currentValue);
+          dom.setCssProperty(css, m.key, m.currentValue == null ? '' : m.currentValue);
 
       mapChangeRecord..forEachRemoval(fn)
                      ..forEachChange(fn)

--- a/lib/directive/ng_template.dart
+++ b/lib/directive/ng_template.dart
@@ -32,8 +32,8 @@ class NgTemplate {
   NgTemplate(this.element, this.templateCache);
   set templateUrl(url) => templateCache.put(url, new HttpResponse(200,
       element is dom.TemplateElement
-          ? (element as dom.TemplateElement).content.innerHtml
-          : element.innerHtml));
+          ? dom.innerHtml(dom.content(element))
+          : dom.innerHtml(element)));
 }
 
 

--- a/lib/dom/dom.dart
+++ b/lib/dom/dom.dart
@@ -1,0 +1,292 @@
+library dom;
+
+import 'dart:html';
+import 'dart:async';
+import 'package:angular/tracing.dart';
+
+export 'dart:html';
+
+
+final _Dom = traceCreateScope('Dom(ascii operation)');
+
+Future<num> animationFrame(Window w) {
+  final s = traceEnter1(_Dom, "animationFrame");
+  final r = w.animationFrame;
+  traceLeave(s);
+  return r;
+}
+
+Node parentNode(Node n) {
+  final s = traceEnter1(_Dom, "parentNode");
+  final r = n.parentNode;
+  traceLeave(s);
+  return r;
+}
+
+
+
+CssStyleDeclaration getComputedStyle(Element e) {
+  final s = traceEnter1(_Dom, "getComputedStyle");
+  final r = e.getComputedStyle();
+  traceLeave(s);
+  return r;
+}
+
+CssStyleDeclaration style(Element e) {
+  final s = traceEnter1(_Dom, "style");
+  final r = e.style;
+  traceLeave(s);
+  return r;
+}
+
+void setCssProperty(CssStyleDeclaration e, String key, String value) {
+  final s = traceEnter1(_Dom, "setCssProperty");
+  e.setProperty(key, value);
+  traceLeave(s);
+}
+
+
+
+void addClass(Element e, String className) {
+  final s = traceEnter1(_Dom, "addClass");
+  e.classes.add(className);
+  traceLeave(s);
+}
+
+void removeClass(Element e, String className) {
+  final s = traceEnter1(_Dom, "removeClass");
+  e.classes.remove(className);
+  traceLeave(s);
+}
+
+CssClassSet classes(Element e) {
+  final s = traceEnter1(_Dom, "classes");
+  final r = e.classes;
+  traceLeave(s);
+  return r;
+}
+
+
+
+void removeNode(Node n) {
+  final s = traceEnter1(_Dom, "removeNode");
+  n.remove();
+  traceLeave(s);
+}
+
+void append(Node n, Node nodeToAppend) {
+  final s = traceEnter1(_Dom, "append");
+  n.append(nodeToAppend);
+  traceLeave(s);
+}
+
+void appendText(Element e, String text) {
+  final s = traceEnter1(_Dom, "appendText");
+  e.appendText(text);
+  traceLeave(s);
+}
+
+
+
+String text(Node n) {
+  final s = traceEnter1(_Dom, "text");
+  final r = n.text;
+  traceLeave(s);
+  return r;
+}
+
+void setText(Node n, String text) {
+  final s = traceEnter1(_Dom, "setText");
+  n.text = text;
+  traceLeave(s);
+}
+
+String innerHtml(elementOrShadowRoot) {
+  assert(elementOrShadowRoot is Element || elementOrShadowRoot is DocumentFragment);
+  final s = traceEnter1(_Dom, "innerHtml");
+  final r = elementOrShadowRoot.innerHtml;
+  traceLeave(s);
+  return r;
+}
+
+void setInnerHtml(Element e, String html, {NodeValidator validator}) {
+  final s = traceEnter1(_Dom, "setInnerHtml");
+  e.setInnerHtml(html, validator: validator);
+  traceLeave(s);
+}
+
+void insertBefore(Node n, Node nodeToInsert, Node insertBefore) {
+  final s = traceEnter1(_Dom, "insertBefore");
+  n.insertBefore(nodeToInsert, insertBefore);
+  traceLeave(s);
+}
+
+void insertAllBefore(Node n, List<Node> nodesToInsert, Node insertBefore){
+  final s = traceEnter1(_Dom, "insertAllBefore");
+  n.insertAllBefore(nodesToInsert, insertBefore);
+  traceLeave(s);
+}
+
+List<Node> nodes(Element e) {
+  final s = traceEnter1(_Dom, "nodes");
+  final r = e.nodes;
+  traceLeave(s);
+  return r;
+}
+
+void setNodes(Element e, List<Node> nodes) {
+  final s = traceEnter1(_Dom, "setNodes");
+  e.nodes = nodes;
+  traceLeave(s);
+}
+
+
+
+
+Map attributes(Element e) {
+  final s = traceEnter1(_Dom, "attributes");
+  final r = e.attributes;
+  traceLeave(s);
+  return r;
+}
+
+String getAttribute(Element e, String name) {
+  final s = traceEnter1(_Dom, "getAttribute");
+  final r = e.getAttribute(name);
+  traceLeave(s);
+  return r;
+}
+
+void removeAttribute(Element e, String name) {
+  final s = traceEnter1(_Dom, "removeAttribute");
+  e.attributes.remove(name);
+  traceLeave(s);
+}
+
+void setAttribute(Element e, String name, value) {
+  final s = traceEnter1(_Dom, "setAttribute");
+  e.setAttribute(name, value);
+  traceLeave(s);
+}
+
+
+bool isChecked(input) {
+  assert(input is CheckboxInputElement || input is OptionElement);
+  final s = traceEnter1(_Dom, "isChecked");
+  final r = input.checked;
+  traceLeave(s);
+  return r;
+}
+
+void setChecked(input, bool value) {
+  assert(input is CheckboxInputElement || input is OptionElement);
+  final s = traceEnter1(_Dom, "setChecked");
+  input.checked = value;
+  traceLeave(s);
+}
+
+String value(input) {
+  assert(input is InputElement || input is OptionElement);
+  final s = traceEnter1(_Dom, "value");
+  final r = input.value;
+  traceLeave(s);
+  return r;
+}
+
+void setValue(input, String value) {
+  assert(input is InputElement || input is OptionElement);
+  final s = traceEnter1(_Dom, "setValue");
+  input.value = value;
+  traceLeave(s);
+}
+
+num valueAsNumber(InputElement e) {
+  final s = traceEnter1(_Dom, "valueAsNumber");
+  final r = e.valueAsNumber;
+  traceLeave(s);
+  return r;
+}
+
+void setValueAsNumber(InputElement e, num value) {
+  final s = traceEnter1(_Dom, "setValueAsNumber");
+  e.valueAsNumber = value;
+  traceLeave(s);
+}
+
+DateTime valueAsDate(InputElement e) {
+  final s = traceEnter1(_Dom, "valueAsDate");
+  final r = e.valueAsDate;
+  traceLeave(s);
+  return r;
+}
+
+void setValueAsDate(InputElement e, DateTime value) {
+  final s = traceEnter1(_Dom, "setValueAsDate");
+  e.valueAsDate = value;
+  traceLeave(s);
+}
+
+void setSelected(OptionElement e, obj) {
+  final s = traceEnter1(_Dom, "setSelected");
+  e.selected = obj;
+  traceLeave(s);
+}
+
+
+
+Node firstChild(Node n) {
+  final s = traceEnter1(_Dom, "firstChild");
+  final r = n.firstChild;
+  traceLeave(s);
+  return r;
+}
+
+DocumentFragment content(TemplateElement e) {
+  final s = traceEnter1(_Dom, "content");
+  final r = e.content;
+  traceLeave(s);
+  return r;
+}
+
+String outerHtml(Element e) {
+  final s = traceEnter1(_Dom, "outerHtml");
+  final r = e.outerHtml;
+  traceLeave(s);
+  return r;
+}
+
+Node nextNode(Node n) {
+  final s = traceEnter1(_Dom, "nextNode");
+  final r = n.nextNode;
+  traceLeave(s);
+  return r;
+}
+
+List querySelectorAll(Element e, String selectors) {
+  final s = traceEnter1(_Dom, "querySelectorAll");
+  final r = e.querySelectorAll(selectors);
+  traceLeave(s);
+  return r;
+}
+
+Node querySelector(Element e, String selectors) {
+  final s = traceEnter1(_Dom, "querySelector");
+  final r = e.querySelector(selectors);
+  traceLeave(s);
+  return r;
+}
+
+
+ShadowRoot createShadowRoot(Element e) {
+  final s = traceEnter1(_Dom, "createShadowRoot");
+  final r = e.createShadowRoot();
+  traceLeave(s);
+  return r;
+}
+
+Node clone(Node n, [bool deep = true]) {
+  final s = traceEnter1(_Dom, "clone");
+  final r = n.clone(deep);
+  traceLeave(s);
+  return r;
+}

--- a/lib/routing/module.dart
+++ b/lib/routing/module.dart
@@ -123,11 +123,10 @@
 library angular.routing;
 
 import 'dart:async';
-import 'dart:html';
-
 import 'package:di/di.dart';
 import 'package:di/annotations.dart';
 import 'package:angular/application.dart';
+import 'package:angular/dom/dom.dart' as dom;
 import 'package:angular/core/annotation_src.dart';
 import 'package:angular/core/module_internal.dart';
 import 'package:angular/core_dom/module_internal.dart';
@@ -143,7 +142,7 @@ part 'ng_bind_route.dart';
 class RoutingModule extends Module {
   RoutingModule({bool usePushState: true}) {
     bind(NgRoutingUsePushState);
-    bind(Router, toFactory: (NgRoutingUsePushState state, Window window) {
+    bind(Router, toFactory: (NgRoutingUsePushState state, dom.Window window) {
       var useFragment = !state.usePushState;
       return new Router(useFragment: useFragment, windowImpl: window);
     }, inject: [NG_ROUTING_USE_PUSH_STATE_KEY, WINDOW_KEY]);

--- a/lib/routing/ng_view.dart
+++ b/lib/routing/ng_view.dart
@@ -63,7 +63,7 @@ class NgView implements DetachAware, RouteProvider {
   final ViewCache _viewCache;
   final Injector _appInjector;
   final DirectiveInjector _dirInjector;
-  final Element _element;
+  final dom.Element _element;
   final Scope _scope;
   RouteHandle _route;
 
@@ -122,14 +122,14 @@ class NgView implements DetachAware, RouteProvider {
       _cleanUp();
       _childScope = _scope.createChild(new PrototypeMap(_scope.context));
       _view = viewFactory(_childScope, _dirInjector);
-      _view.nodes.forEach((elm) => _element.append(elm));
+      _view.nodes.forEach((elm) => dom.append(_element, elm));
     });
   }
 
   void _cleanUp() {
     if (_view == null) return;
 
-    _view.nodes.forEach((node) => node.remove());
+    _view.nodes.forEach((node) => dom.removeNode(node));
     _childScope.destroy();
     _view = null;
     _childScope = null;


### PR DESCRIPTION
This PR hides DOM-access operations behind a facade. Having this facade enables better instrumentation. For instance, we can add WTF trace calls, so in the profiler you can see all the DOM operations, how long they took, etc. 
