### PR TITLE
perf(view): increase view instantiation speed 40%

### DIFF
--- a/lib/core_dom/directive.dart
+++ b/lib/core_dom/directive.dart
@@ -22,7 +22,7 @@ class NodeAttrs {
 
   NodeAttrs(this.element);
 
-  operator [](String attrName) => element.attributes[attrName];
+  operator [](String attrName) => element.getAttribute(attrName);
 
   void operator []=(String attrName, String value) {
     if (_mustacheAttrs.containsKey(attrName)) {
@@ -31,7 +31,7 @@ class NodeAttrs {
     if (value == null) {
       element.attributes.remove(attrName);
     } else {
-      element.attributes[attrName] = value;
+      element.setAttribute(attrName, value);
     }
 
     if (_observers != null && _observers.containsKey(attrName)) {
@@ -86,9 +86,18 @@ class NodeAttrs {
  * ShadowRoot is ready.
  */
 class TemplateLoader {
-  final async.Future<dom.Node> template;
+  async.Future<dom.Node> _template;
+  List<async.Future> _futures;
+  final dom.Node _shadowRoot;
 
-  TemplateLoader(this.template);
+  TemplateLoader(this._shadowRoot, this._futures);
+
+  async.Future<dom.Node> get template {
+    if (_template == null) {
+      _template = async.Future.wait(_futures).then((_) => _shadowRoot);
+    }
+    return _template;
+  }
 }
 
 class _MustacheAttr {

--- a/lib/core_dom/shadow_dom_component_factory.dart
+++ b/lib/core_dom/shadow_dom_component_factory.dart
@@ -11,7 +11,7 @@ abstract class BoundComponentFactory {
   List<Key> get callArgs;
   Function call(dom.Element element);
 
-  static async.Future<ViewFactory> _viewFuture(
+  static async.Future<ViewFactory> _viewFactoryFuture(
         Component component, ViewCache viewCache, DirectiveMap directives) {
     if (component.template != null) {
       return new async.Future.value(viewCache.fromHtml(component.template, directives));
@@ -67,20 +67,27 @@ class BoundShadowDomComponentFactory implements BoundComponentFactory {
   Component get _component => _ref.annotation as Component;
 
   String _tag;
-  async.Future<Iterable<dom.StyleElement>> _styleElementsFuture;
-  async.Future<ViewFactory> _viewFuture;
+  async.Future<List<dom.StyleElement>> _styleElementsFuture;
+  List<dom.StyleElement> _styleElements;
+  async.Future<ViewFactory> _shadowViewFactoryFuture;
+  ViewFactory _shadowViewFactory;
 
   BoundShadowDomComponentFactory(this._componentFactory, this._ref, this._directives, this._injector) {
     _tag = _component.selector.toLowerCase();
-    _styleElementsFuture = async.Future.wait(_component.cssUrls.map(_styleFuture));
+    _styleElementsFuture = async.Future.wait(_component.cssUrls.map(_urlToStyle))
+        ..then((stylesElements) => _styleElements = stylesElements);
 
-    _viewFuture = BoundComponentFactory._viewFuture(
+    _shadowViewFactoryFuture = BoundComponentFactory._viewFactoryFuture(
         _component,
+        // TODO(misko): Why do we create a new one per Component. This kind of defeats the caching.
         new PlatformViewCache(_componentFactory.viewCache, _tag, _componentFactory.platform),
         _directives);
+    if (_shadowViewFactoryFuture != null) {
+      _shadowViewFactoryFuture.then((viewFactory) => _shadowViewFactory = viewFactory);
+    }
   }
 
-  async.Future<dom.StyleElement> _styleFuture(cssUrl) {
+  async.Future<dom.StyleElement> _urlToStyle(cssUrl) {
     Http http = _componentFactory.http;
     TemplateCache templateCache = _componentFactory.templateCache;
     WebPlatform platform = _componentFactory.platform;
@@ -109,7 +116,7 @@ class BoundShadowDomComponentFactory implements BoundComponentFactory {
 
           // If the css shim is required, it means that scoping does not
           // work, and adding the style to the head of the document is
-          // preferrable.
+          // preferable.
           if (platform.cssShimRequired) {
             dom.document.head.append(styleElement);
             return null;
@@ -128,50 +135,59 @@ class BoundShadowDomComponentFactory implements BoundComponentFactory {
             EventHandler _) {
       var s = traceEnter(View_createComponent);
       try {
-        var shadowDom = element.createShadowRoot()
+        var shadowScope = scope.createChild(new HashMap()); // Isolate
+        ComponentDirectiveInjector shadowInjector;
+        dom.ShadowRoot shadowRoot = element.createShadowRoot();
+        shadowRoot
           ..applyAuthorStyles = _component.applyAuthorStyles
           ..resetStyleInheritance = _component.resetStyleInheritance;
 
-        var shadowScope = scope.createChild(new HashMap()); // Isolate
+        List<async.Future> futures = <async.Future>[];
+        TemplateLoader templateLoader = new TemplateLoader(shadowRoot, futures);
+        var eventHandler = new ShadowRootEventHandler(
+            shadowRoot, injector.getByKey(EXPANDO_KEY), injector.getByKey(EXCEPTION_HANDLER_KEY));
+        shadowInjector = new ComponentDirectiveInjector(
+            injector, this._injector, eventHandler, shadowScope, templateLoader, shadowRoot, null);
+        shadowInjector.bindByKey(_ref.typeKey, _ref.factory, _ref.paramKeys,
+            _ref.annotation.visibility);
+        dom.Node firstViewNode = null;
 
-        async.Future<Iterable<dom.StyleElement>> cssFuture;
-        if (_component.useNgBaseCss == true) {
-          cssFuture = async.Future.wait([async.Future.wait(baseCss.urls.map(_styleFuture)), _styleElementsFuture]).then((twoLists) {
-            assert(twoLists.length == 2);return []
-              ..addAll(twoLists[0])
-              ..addAll(twoLists[1]);
-          });
-        } else {
-          cssFuture = _styleElementsFuture;
+        // Load ngBase CSS
+        if (_component.useNgBaseCss == true && baseCss.urls.isNotEmpty) {
+          if (baseCss.styles == null) {
+            futures.add(async.Future
+                .wait(baseCss.urls.map(_urlToStyle))
+                .then((List<dom.StyleElement> cssList) {
+                  baseCss.styles = cssList;
+                  _insertCss(cssList, shadowRoot, shadowRoot.firstChild);
+                }));
+          } else {
+            _insertCss(baseCss.styles, shadowRoot, shadowRoot.firstChild);
+          }
         }
 
-        ComponentDirectiveInjector shadowInjector;
-
-        TemplateLoader templateLoader = new TemplateLoader(cssFuture.then((Iterable<dom.StyleElement> cssList) {
-          cssList.where((styleElement) => styleElement != null).forEach((styleElement) {
-            shadowDom.append(styleElement.clone(true));
-          });
-          if (_viewFuture != null) {
-            return _viewFuture.then((ViewFactory viewFactory) {
-              if (shadowScope.isAttached) {
-                shadowDom.nodes.addAll(viewFactory.call(shadowInjector.scope, shadowInjector).nodes);
-              }
-              return shadowDom;
-            });
+        if (_styleElementsFuture != null) {
+          if (_styleElements == null) {
+            futures.add(_styleElementsFuture .then((List<dom.StyleElement> styles) =>
+                _insertCss(styles, shadowRoot, firstViewNode)));
+          } else {
+            _insertCss(_styleElements, shadowRoot);
           }
-          return shadowDom;
-        }));
+        }
 
-        var probe;
-        var eventHandler = new ShadowRootEventHandler(
-            shadowDom, injector.getByKey(EXPANDO_KEY), injector.getByKey(EXCEPTION_HANDLER_KEY));
-        shadowInjector = new ComponentDirectiveInjector(injector, _injector, eventHandler, shadowScope,
-            templateLoader, shadowDom, null);
-        shadowInjector.bindByKey(_ref.typeKey, _ref.factory, _ref.paramKeys, _ref.annotation.visibility);
+
+        if (_shadowViewFactoryFuture != null) {
+          if (_shadowViewFactory == null) {
+            futures.add(_shadowViewFactoryFuture.then((ViewFactory viewFactory) =>
+                firstViewNode = _insertView(viewFactory, shadowRoot, shadowScope, shadowInjector)));
+          } else {
+            _insertView(_shadowViewFactory, shadowRoot, shadowScope, shadowInjector);
+          }
+        }
 
         if (_componentFactory.config.elementProbeEnabled) {
-          probe = _componentFactory.expando[shadowDom] = shadowInjector.elementProbe;
-          shadowScope.on(ScopeEvent.DESTROY).listen((ScopeEvent) => _componentFactory.expando[shadowDom] = null);
+          ElementProbe probe = _componentFactory.expando[shadowRoot] = shadowInjector.elementProbe;
+          shadowScope.on(ScopeEvent.DESTROY).listen((ScopeEvent) => _componentFactory.expando[shadowRoot] = null);
         }
 
         var controller = shadowInjector.getByKey(_ref.typeKey);
@@ -184,6 +200,36 @@ class BoundShadowDomComponentFactory implements BoundComponentFactory {
         traceLeave(s);
       }
     };
+  }
+
+  _insertCss(List<dom.StyleElement> cssList,
+             dom.ShadowRoot shadowRoot,
+             [dom.Node insertBefore = null]) {
+    var s = traceEnter(View_styles);
+    for(int i = 0; i < cssList.length; i++) {
+      var styleElement = cssList[i];
+      if (styleElement != null) {
+        shadowRoot.insertBefore(styleElement.clone(true), insertBefore);
+      }
+    }
+    traceLeave(s);
+  }
+
+  dom.Node _insertView(ViewFactory viewFactory,
+              dom.ShadowRoot shadowRoot,
+              Scope shadowScope,
+              ComponentDirectiveInjector shadowInjector) {
+    dom.Node first = null;
+    if (shadowScope.isAttached) {
+      View shadowView = viewFactory.call(shadowScope, shadowInjector);
+      List<dom.Node> shadowViewNodes = shadowView.nodes;
+      for (var j = 0; j < shadowViewNodes.length; j++) {
+        var node = shadowViewNodes[j];
+        if (j == 0) first = node;
+        shadowRoot.append(node);
+      }
+    }
+    return first;
   }
 }
 

--- a/lib/core_dom/view_factory.dart
+++ b/lib/core_dom/view_factory.dart
@@ -86,10 +86,12 @@ class ViewFactory implements Function {
     }
     elementInjectors[elementBinderIndex] = elementInjector;
 
-    if (tagged.textBinders != null) {
-      for (var k = 0; k < tagged.textBinders.length; k++) {
-        TaggedTextBinder taggedText = tagged.textBinders[k];
-        var childNode = boundNode.childNodes[taggedText.offsetIndex];
+    var textBinders = tagged.textBinders;
+    if (textBinders != null && textBinders.length > 0) {
+      var childNodes = boundNode.childNodes;
+      for (var k = 0; k < textBinders.length; k++) {
+        TaggedTextBinder taggedText = textBinders[k];
+        var childNode = childNodes[taggedText.offsetIndex];
         taggedText.binder.bind(view, scope, elementInjector, childNode);
       }
     }
@@ -103,15 +105,6 @@ class ViewFactory implements Function {
     for (int i = 0; i < nodeList.length; i++) {
       dom.Node node = nodeList[i];
       NodeLinkingInfo linkingInfo = nodeLinkingInfos[i];
-
-      // if node isn't attached to the DOM, create a parent for it.
-      var parentNode = node.parentNode;
-      var fakeParent = false;
-      if (parentNode == null) {
-        fakeParent = true;
-        parentNode = new dom.DivElement();
-        parentNode.append(node);
-      }
 
       if (linkingInfo.isElement) {
         if (linkingInfo.containsNgBinding) {
@@ -137,11 +130,6 @@ class ViewFactory implements Function {
               elementInjectors, view, node, scope);
         }
         elementBinderIndex++;
-      }
-
-      if (fakeParent) {
-        // extract the node from the parentNode.
-        nodeList[i] = parentNode.nodes[0];
       }
     }
     return view;

--- a/lib/core_dom/web_platform.dart
+++ b/lib/core_dom/web_platform.dart
@@ -42,7 +42,7 @@ class WebPlatform {
       //
       // TODO Remove the try-catch once https://github.com/angular/angular.dart/issues/1189 is fixed.
       try {
-        root.querySelectorAll("*").forEach((n) => n.attributes[selector] = "");
+        root.querySelectorAll("*").forEach((dom.Element n) => n.setAttribute(selector, ""));
       } catch (e, s) {
         print("WARNING: Failed to set up Shadow DOM shim for $selector.\n$e\n$s");
       }
@@ -69,6 +69,7 @@ class PlatformViewCache implements ViewCache {
     if (selector != null && selector != "" && platform.shadowDomShimRequired) {
       // By adding a comment with the tag name we ensure the template html is unique per selector
       // name when used as a key in the view factory cache.
+      //TODO(misko): This will always be miss, since we never put it in cache under such key.
       viewFactory = viewFactoryCache.get("<!-- Shimmed template for: <$selector> -->$html");
     } else {
       viewFactory = viewFactoryCache.get(html);

--- a/lib/directive/ng_base_css.dart
+++ b/lib/directive/ng_base_css.dart
@@ -12,10 +12,14 @@ part of angular.directive;
     selector: '[ng-base-css]',
     visibility: Visibility.CHILDREN)
 class NgBaseCss {
+  List<dom.StyleElement> styles;
   List<String> _urls = const [];
 
   @NgAttr('ng-base-css')
-  set urls(v) => _urls = v is List ? v : [v];
+  set urls(v) {
+    _urls = v is List ? v : [v];
+    styles = null;
+  }
 
   List<String> get urls => _urls;
 }

--- a/lib/ng_tracing_scopes.dart
+++ b/lib/ng_tracing_scopes.dart
@@ -172,6 +172,13 @@ final View_create = traceCreateScope('View#create(ascii html)');
 final View_createComponent = traceCreateScope('View#createComponent()');
 
 /**
+ * Name: `View#styles()`
+ *
+ * Designates where styles are inserted into component.
+ */
+final View_styles = traceCreateScope('View#styles()');
+
+/**
  * Name: `Directive#create(ascii name)`
  *
  * Designates a particular directive is created. This includes the setting up of bindings for

--- a/test/core_dom/compiler_spec.dart
+++ b/test/core_dom/compiler_spec.dart
@@ -931,7 +931,7 @@ void main() {
       }));
 
       /*
-        This test is dissabled becouse I (misko) thinks it has no real use case. It is easier
+        This test is disabled because I (misko) thinks it has no real use case. It is easier
         to understand in terms of ng-repeat
 
           <tabs>
@@ -945,7 +945,7 @@ void main() {
           the DirectChild between tabs and pane.
 
           It is not clear to me (misko) that there is a use case for getting hold of the
-          tranrscluding directive such a ng-repeat.
+          transcluding directive such a ng-repeat.
        */
       xit('should reuse controllers for transclusions', async((Logger log) {
         _.compile('<div simple-transclude-in-attach include-transclude>view</div>');

--- a/test/directive/ng_base_css_spec.dart
+++ b/test/directive/ng_base_css_spec.dart
@@ -23,22 +23,35 @@ main() => describe('NgBaseCss', () {
       ..bind(_NoBaseCssComponent);
   });
 
-  it('should load css urls from ng-base-css', async((TestBed _, MockHttpBackend backend) {
+  it('should load css urls from ng-base-css', async((TestBed _, MockHttpBackend backend,
+                                                      DirectiveMap directiveMap) {
     backend
       ..expectGET('simple.css').respond(200, '.simple{}')
       ..expectGET('simple.html').respond(200, '<div>Simple!</div>')
       ..expectGET('base.css').respond(200, '.base{}');
 
-    var element = e('<div ng-base-css="base.css"><html-and-css>ignore</html-and-css></div>');
-    _.compile(element);
+    NgBaseCss ngBaseCss = new NgBaseCss();
+    ngBaseCss.urls = 'base.css';
+    DirectiveInjector directiveInjector = new DirectiveInjector(
+        null, _.injector, null, null, null, null, null);
+    directiveInjector.bind(NgBaseCss, toValue: ngBaseCss, visibility: Visibility.CHILDREN);
+    var elements = es('<div><html-and-css>ignore</html-and-css></div>');
+    ViewFactory viewFactory = _.compiler(elements, directiveMap);
+    View view = viewFactory.call(_.rootScope, directiveInjector);
 
     microLeap();
     backend.flush();
     microLeap();
 
-    expect(element.children[0].shadowRoot).toHaveHtml(
-            '<style>.base{}</style><style>.simple{}</style><div>Simple!</div>'
-        );
+    expect((view.nodes[0].firstChild as Element).shadowRoot).toHaveHtml(
+            '<style>.base{}</style><style>.simple{}</style><div>Simple!</div>');
+    expect(ngBaseCss.styles.first.innerHtml).toEqual('.base{}');
+
+    // Now it should be sync
+    view = viewFactory.call(_.rootScope, directiveInjector);
+    expect((view.nodes[0].firstChild as Element).shadowRoot).toHaveHtml(
+            '<style>.base{}</style><style>.simple{}</style><div>Simple!</div>');
+
   }));
 
   it('ng-base-css should overwrite parent ng-base-csses', async((TestBed _, MockHttpBackend backend) {


### PR DESCRIPTION
1) Stop using futures when the value is already cached
2) Remove adding nodes to fake parent during view instantiation

Closes #1358

This PR fails some tests and needs more work.
