### PR TITLE
fix(travis): BUILD_LEADER is not available in build.sh

### DIFF
--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -128,7 +128,7 @@ fi
 echo '-------------------------'
 echo '-- DOCS: Generate Docs --'
 echo '-------------------------'
-if [[ $BUILD_LEADER == "YES" ]]; then
+if [[ ${TRAVIS_JOB_NUMBER:(-2)} == ".1" ]]; then
   echo $NGDART_SCRIPT_DIR/generate-documentation.sh;
   $NGDART_SCRIPT_DIR/generate-documentation.sh;
 fi

--- a/scripts/travis/publish-docs.sh
+++ b/scripts/travis/publish-docs.sh
@@ -11,7 +11,7 @@ echo Current branch is: $TRAVIS_BRANCH
 echo Test result is: $TRAVIS_TEST_RESULT
 
 if [ "$TRAVIS_REPO_SLUG" = "angular/angular.dart" ]; then
-  if [ $TRAVIS_TEST_RESULT -eq 0 ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+  if [ $TRAVIS_TEST_RESULT -eq 0 ] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
     echo "Gettting current docs from docs.angulardart.org repo on Github"
     rm -Rf docs.angulardart.org
     git clone https://github.com/angular/docs.angulardart.org.git


### PR DESCRIPTION
Replace with check that TRAVIS_JOB_NUMBER ends at .1.

Closes #1362
