### PR TITLE
fix(perf_api): updgrade the pkg minimum version to fix an analyzer error

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   di: '>=2.0.1 <3.0.0'
   html5lib: '>=0.10.0 <0.11.0'
   intl: '>=0.8.7 <0.12.0'
-  perf_api: '>=0.0.8 <0.1.0'
+  perf_api: '>=0.0.9 <0.1.0'
   route_hierarchical: '>=0.4.22 <0.5.0'
 dev_dependencies:
   benchmark_harness: '>=1.0.0 <2.0.0'


### PR DESCRIPTION
fixes #1407

perf_api 0.0.8 contains an invalid const constructor which the type
checker ignored in dart 1.5.8 but throws on in 1.6. Using 0.0.9 fixes
this.
