### PR TITLE
fix: remove analyze warnings

### DIFF
--- a/lib/core_dom/light_dom.dart
+++ b/lib/core_dom/light_dom.dart
@@ -1,11 +1,9 @@
 part of angular.core.dom_internal;
 
-@Injectable()
 abstract class SourceLightDom {
   void redistribute();
 }
 
-@Injectable()
 abstract class DestinationLightDom {
   void redistribute();
   void addViewPort(ViewPort viewPort);

--- a/test/core_dom/light_dom_spec.dart
+++ b/test/core_dom/light_dom_spec.dart
@@ -9,6 +9,8 @@ class DummyContent extends Mock implements Content {
   List<Node> nodes = [];
   DummyContent(this.select);
   insert(nodes) => this.nodes = new List.from(nodes);
+  // Prevent analyzer from complaining about missing method impl
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 void main() {

--- a/test/core_dom/ng_element_spec.dart
+++ b/test/core_dom/ng_element_spec.dart
@@ -2,7 +2,10 @@ library ng_element_spec;
 
 import '../_specs.dart';
 
-class _MockLightDom extends Mock implements DestinationLightDom {}
+class _MockLightDom extends Mock implements DestinationLightDom {
+  // Prevent analyzer from complaining about missing method impl
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
 
 void main() {
   describe('ngElement', () {

--- a/test/core_dom/view_spec.dart
+++ b/test/core_dom/view_spec.dart
@@ -60,7 +60,10 @@ class BFormatter {
   call(value) => value;
 }
 
-class _MockLightDom extends Mock implements DestinationLightDom {}
+class _MockLightDom extends Mock implements DestinationLightDom {
+  // Prevent analyzer from complaining about missing method impl
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
 
 main() {
   describe('View', () {
@@ -73,7 +76,7 @@ main() {
     ViewPort createViewPort({Injector injector, DestinationLightDom lightDom}) {
       final scope = injector.get(Scope);
       final view = new View([], scope);
-      final di =new DirectiveInjector(null, injector, null, null, null, null, null, view);
+      final di = new DirectiveInjector(null, injector, null, null, null, null, null, view);
       return new ViewPort(di, scope, rootElement.childNodes[0], injector.get(Animate), lightDom);
     }
 


### PR DESCRIPTION
Small tweaks to remove analyzer warnings:
- `noSuchMethod` seems like a limitation of the analyzer,
- `@Injectable` must not be put on abstract class - we don't need it when doing value binding
