### PR TITLE
fix(components): the content tag duplicates elements

### DIFF
--- a/lib/core_dom/light_dom.dart
+++ b/lib/core_dom/light_dom.dart
@@ -24,7 +24,9 @@ class LightDom implements SourceLightDom, DestinationLightDom {
 
   void pullNodes() {
     _lightDomRootNodes.addAll(_componentElement.nodes);
+  }
 
+  void clearComponentElement() {
     // This is needed because _lightDomRootNodes can contains viewports,
     // which cannot be detached.
     final fakeRoot = new dom.DivElement();

--- a/lib/core_dom/transcluding_component_factory.dart
+++ b/lib/core_dom/transcluding_component_factory.dart
@@ -53,15 +53,14 @@ class BoundTranscludingComponentFactory implements BoundComponentFactory {
       var childInjectorCompleter; // Used if the ViewFuture is available before the childInjector.
 
       var component = _component;
-      var lightDom = new LightDom(element, scope);
+      var lightDom = new LightDom(element, scope)..pullNodes();
 
       // Append the component's template as children
       var elementFuture;
 
       if (_viewFuture != null) {
         elementFuture = _viewFuture.then((ViewFactory viewFactory) {
-          lightDom.pullNodes();
-
+          lightDom.clearComponentElement();
           if (childInjector != null) {
             lightDom.shadowDomView = viewFactory.call(childInjector.scope, childInjector);
             return element;
@@ -74,7 +73,7 @@ class BoundTranscludingComponentFactory implements BoundComponentFactory {
           }
         });
       } else {
-        elementFuture = new async.Future.microtask(() => lightDom.pullNodes());
+        elementFuture = new async.Future.microtask(lightDom.clearComponentElement);
       }
       TemplateLoader templateLoader = new TemplateLoader(elementFuture);
 


### PR DESCRIPTION
Change the component factory to pull light DOM elements before they get compiled. It is important when the light dom has viewport nodes, because they change their siblings.
