### PR TITLE
test(parser_spec): fix analyzer warnings

### DIFF
--- a/test/core/parser/parser_spec.dart
+++ b/test/core/parser/parser_spec.dart
@@ -49,7 +49,7 @@ toBool(x) => (x is num) ? x != 0 : x == true;
 main() {
   describe('parse', () {
     Map<String, dynamic> context;
-    Parser<Expression> parser;
+    Parser parser;
     FormatterMap formatters;
 
     beforeEachModule((Module module) {
@@ -157,7 +157,7 @@ main() {
     });
 
     describe('error handling', () {
-      Parser<Expression> parser;
+      Parser parser;
 
       beforeEach((Parser p) {
         parser = p;


### PR DESCRIPTION
fix for

```
base/test/core/parser/parser_spec.dart:52:12:
Warning: Additional type argument.
    Parser<Expression> parser;
           ^^^^^^^^^^
base/test/core/parser/parser_spec.dart:160:14:
Warning: Additional type argument.
      Parser<Expression> parser;
             ^^^^^^^^^^
```
