### PR TITLE
feat(directive injector): Assert that the injector has been initialized

### DIFF
--- a/lib/core_dom/directive_injector.dart
+++ b/lib/core_dom/directive_injector.dart
@@ -196,6 +196,7 @@ class DirectiveInjector implements DirectiveBinder {
   }
 
   void bindByKey(Key key, Function factory, List<Key> parameterKeys, [Visibility visibility]) {
+    assert(_isInit);
     if (visibility == null) visibility = Visibility.CHILDREN;
     int visibilityId = _toVisId(visibility);
     int keyVisId = key.uid;


### PR DESCRIPTION
The directive injector is normally initialized by the angular application.

However while doing some tests, I was not booting an ng app but only the strict minimum for my tests. It turned that the injector was not initialized.
