### PR TITLE
fix(routing): Update route_hierarchical to 0.5 or later

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -66,7 +66,7 @@ packages:
   route_hierarchical:
     description: route_hierarchical
     source: hosted
-    version: "0.4.22"
+    version: "0.5.0"
   source_maps:
     description: source_maps
     source: hosted

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -80,7 +80,7 @@ packages:
   route_hierarchical:
     description: route_hierarchical
     source: hosted
-    version: "0.4.22"
+    version: "0.5.0"
   source_maps:
     description: source_maps
     source: hosted

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   html5lib: '>=0.10.0 <0.11.0'
   intl: '>=0.8.7 <0.12.0'
   perf_api: '>=0.0.9 <0.1.0'
-  route_hierarchical: '>=0.4.22 <0.5.0'
+  route_hierarchical: '>=0.5.0 <0.6.0'
 dev_dependencies:
   benchmark_harness: '>=1.0.0 <2.0.0'
   guinness: '>=0.1.9 <0.2.0'


### PR DESCRIPTION
Increased route_hierarchical version boundary to include changes in v0.5 that contains fixes for ios. The bug meant that on ios when parameters are used after a certain amount of time you will not be able to change route.
