### PR TITLE
refactor(NgElement): NgElement inject RootScope instead of Scope.

### DIFF
--- a/lib/core_dom/directive_injector.dart
+++ b/lib/core_dom/directive_injector.dart
@@ -387,7 +387,7 @@ class DirectiveInjector implements DirectiveBinder {
 
   NgElement get ngElement {
     if (_ngElement == null) {
-      _ngElement = new NgElement(_node, scope, _animate, _destLightDom);
+      _ngElement = new NgElement(_node, _appInjector.getByKey(ROOT_SCOPE_KEY), _animate, _destLightDom);
     }
     return _ngElement;
   }

--- a/lib/core_dom/ng_element.dart
+++ b/lib/core_dom/ng_element.dart
@@ -5,7 +5,7 @@ class NgElement {
   static const _TO_BE_REMOVED = const Object();
 
   final dom.Element node;
-  final Scope _scope;
+  final RootScope _rootScope;
   final Animate _animate;
   final DestinationLightDom _lightDom;
 
@@ -14,7 +14,7 @@ class NgElement {
 
   bool _writeScheduled = false;
 
-  NgElement(this.node, this._scope, this._animate, [this._lightDom]);
+  NgElement(this.node, this._rootScope, this._animate, [this._lightDom]);
 
   void addClass(String className) {
     _scheduleDomWrite();
@@ -40,7 +40,7 @@ class NgElement {
   _scheduleDomWrite() {
     if (!_writeScheduled) {
       _writeScheduled = true;
-      _scope.rootScope.domWrite(() {
+      _rootScope.domWrite(() {
         _writeToDom();
         _notifyLightDom();
         _writeScheduled = false;


### PR DESCRIPTION
NgElement only uses scope to access rootScope, so now we directly inject
RootScope.

This is needed for future change #1429 which disallows Scope injection
into controllers. Since NgElement depends on scope it would also be
disallowed, unless we change it to directly use RootScope.
