### PR TITLE
fix(components): do not reinsert nodes during redistribution if they hav...

### DIFF
--- a/lib/core_dom/content_tag.dart
+++ b/lib/core_dom/content_tag.dart
@@ -34,6 +34,8 @@ class _RenderedTranscludingContent implements _ContentStrategy {
   dom.ScriptElement _beginScript;
   dom.ScriptElement _endScript;
 
+  Iterable<dom.Node> _currNodes;
+
   _RenderedTranscludingContent(this._content, this._sourceLightDom);
 
   void attach(){
@@ -48,8 +50,14 @@ class _RenderedTranscludingContent implements _ContentStrategy {
 
   void insert(Iterable<dom.Node> nodes){
     final p = _endScript.parent;
-    if (p != null) p.insertAllBefore(nodes, _endScript);
+    if (p != null && ! _equalToCurrNodes(nodes)) {
+      _currNodes = nodes.toList();
+      p.insertAllBefore(nodes, _endScript);
+    }
   }
+
+  bool _equalToCurrNodes(Iterable<dom.Node> nodes) =>
+      const IterableEquality().equals(_currNodes, nodes);
 
   void _replaceContentElementWithScriptTags() {
     _beginScript = _beginScriptTemplate.clone(true);

--- a/lib/core_dom/module_internal.dart
+++ b/lib/core_dom/module_internal.dart
@@ -10,6 +10,7 @@ import 'package:di/annotations.dart';
 import 'package:perf_api/perf_api.dart';
 import 'package:logging/logging.dart';
 
+import 'package:collection/equality.dart';
 import 'package:angular/utils.dart';
 import 'package:angular/cache/module.dart';
 

--- a/test/core_dom/compiler_spec.dart
+++ b/test/core_dom/compiler_spec.dart
@@ -316,6 +316,28 @@ void main() {
           microLeap(); _.rootScope.apply();
         }));
 
+        it('should not lose focus', async(() {
+          if (compilerType != 'transcluding') return;
+
+          _.rootScope.context['showClass'] = false;
+          var element = _.compile(r'<simple>'
+              '''aaa <input type="text" id="focused-input" ng-class="{'aClass' : showClass}"> bbb'''
+            '</simple>');
+          document.body.append(element);
+          microLeap(); _.rootScope.apply();
+
+          InputElement input = element.querySelector("#focused-input");
+          input.focus();
+
+          expect(document.activeElement.id).toEqual("focused-input");
+
+          // trigger redistribution
+          _.rootScope.context['showClass'] = true;
+          microLeap(); _.rootScope.apply();
+
+          expect(document.activeElement.id).toEqual("focused-input");
+        }));
+
         it('should support multiple content tags', async(() {
           var element = _.compile(r'<div>'
             '<multiple-content-tags>'


### PR DESCRIPTION
...e not changed
1. It improves the performance of redistribution by 8-10%.
2. It helps input elements keep the focused state (https://github.com/angular/angular.dart/issues/1444).
