### PR TITLE
perf(util): call toLowerCase() only where needed

### DIFF
--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -82,9 +82,8 @@ relaxFnArgs(Function fn) {
 capitalize(String s) => s.substring(0, 1).toUpperCase() + s.substring(1);
 
 String camelCase(String s) {
-  var part = s.split('-').map((s) => s.toLowerCase());
-  if (part.length <= 1) return part.join();
-  return part.first + part.skip(1).map(capitalize).join();
+  var parts = s.split('-');
+  return parts.first.toLowerCase() + parts.skip(1).map(capitalize).join();
 }
 
 /// Returns whether or not the given identifier is a reserved word in Dart.

--- a/test/utils_spec.dart
+++ b/test/utils_spec.dart
@@ -44,6 +44,10 @@ main() {
     it('should lowercase strings', () {
       expect(camelCase('Caps-first')).toEqual('capsFirst');
     });
+
+    it('should work on empty string', () {
+      expect(camelCase('')).toEqual('');
+    });
   });
 }
 


### PR DESCRIPTION
There is no need to lowerCase all parts as we'll capitalize them later. Marginally faster.
