### PR TITLE
fix(Scope): If _getters returns exception angular crashes

### DIFF
--- a/example/web/ng_if.dart
+++ b/example/web/ng_if.dart
@@ -1,0 +1,42 @@
+import 'package:angular/angular.dart';
+import 'package:angular/application_factory.dart';
+
+import '../packages/quiver/core.dart'; 
+
+main() {
+  var module = new Module()..bind(MainComponent)..bind(ComponentTwo);
+
+  applicationFactory()
+      .addModule(module)
+      .run();
+}
+
+@Component(
+  selector: 'cmp-one',
+  template: '''<div>
+  <input type="checkbox" ng-model="ctrl.optionalPresent" />
+  <label>Toggle optional</label>
+</div>
+<div ng-if="ctrl.optional.isPresent">
+  <cmp-two value="ctrl.optional.value" />
+</div>''',
+  publishAs: 'ctrl')
+class MainComponent {
+  Optional<String> optional = new Optional.absent();
+
+  int count = 1;
+  
+  bool get optionalPresent => optional.isPresent;
+  void set optionalPresent(bool value) {
+    optional = new Optional.fromNullable(value ? "optionalPresent" + (count++).toString() : null);
+  }
+}
+
+@Component(
+  selector: 'cmp-two',
+  template: '<div>{{ctrl.value}}</div>',
+  publishAs: 'ctrl')
+class ComponentTwo {
+  @NgOneWay('value')
+  String value;
+}

--- a/example/web/ng_if.html
+++ b/example/web/ng_if.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+  	<meta charset="utf-8">
+  	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ng_if</title>
+  </head>
+ 
+  <body>   
+    <cmp-one></cmp-one>
+    <script type="application/dart" src="ng_if.dart"></script>
+    <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
+    <script src="packages/browser/dart.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Fixes #1446

Fixes issue where  DirtyCheckChangeDetector check() when getting value
using getters. If the getter returns exception would cause change
detection to fail.
