### PR TITLE
chore(DI): update to v3.1.1+

### DIFF
--- a/benchmark/pubspec.lock
+++ b/benchmark/pubspec.lock
@@ -4,13 +4,13 @@ packages:
   analyzer:
     description: analyzer
     source: hosted
-    version: "0.15.7"
+    version: "0.18.0"
   angular:
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.11.0"
+    version: "0.14.0"
   args:
     description: args
     source: hosted
@@ -18,7 +18,7 @@ packages:
   barback:
     description: barback
     source: hosted
-    version: "0.13.0"
+    version: "0.14.2"
   benchmark_harness:
     description: benchmark_harness
     source: hosted
@@ -30,17 +30,15 @@ packages:
   code_transformers:
     description: code_transformers
     source: hosted
-    version: "0.1.4+2"
+    version: "0.1.6"
   collection:
     description: collection
     source: hosted
-    version: "0.9.2"
+    version: "0.9.4"
   di:
-    description:
-      path: "../../di.dart"
-      relative: true
-    source: path
-    version: "2.0.0-alpha.9"
+    description: di
+    source: hosted
+    version: "3.1.1"
   html5lib:
     description: html5lib
     source: hosted
@@ -48,48 +46,60 @@ packages:
   intl:
     description: intl
     source: hosted
-    version: "0.9.10"
+    version: "0.11.8"
   logging:
     description: logging
     source: hosted
-    version: "0.9.1+1"
+    version: "0.9.2"
   matcher:
     description: matcher
     source: hosted
-    version: "0.10.0"
+    version: "0.11.1"
   mock:
     description: mock
     source: hosted
-    version: "0.10.0+1"
+    version: "0.11.0+2"
   path:
     description: path
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   perf_api:
     description: perf_api
     source: hosted
-    version: "0.0.8"
+    version: "0.0.9"
+  petitparser:
+    description: petitparser
+    source: hosted
+    version: "1.2.2"
+  pool:
+    description: pool
+    source: hosted
+    version: "1.0.1"
   route_hierarchical:
     description: route_hierarchical
     source: hosted
-    version: "0.4.21"
+    version: "0.4.22"
   source_maps:
     description: source_maps
     source: hosted
-    version: "0.9.0"
+    version: "0.9.4"
+  source_span:
+    description: source_span
+    source: hosted
+    version: "1.0.0"
   stack_trace:
     description: stack_trace
     source: hosted
-    version: "0.9.3+1"
+    version: "1.0.2"
+  typed_mock:
+    description: typed_mock
+    source: hosted
+    version: "0.0.4"
   unittest:
     description: unittest
     source: hosted
-    version: "0.10.1+2"
+    version: "0.11.0+5"
   utf:
     description: utf
     source: hosted
-    version: "0.9.0"
-  web_components:
-    description: web_components
-    source: hosted
-    version: "0.3.3"
+    version: "0.9.0+1"

--- a/benchmark/web/tree.dart
+++ b/benchmark/web/tree.dart
@@ -30,7 +30,7 @@ class TreeComponent {
     publishAs: 'ctrl',
     useShadowDom: false)
 class TranscludingTreeComponent extends TreeComponent {}
-  
+
 
 @Component(
     selector: 'tree-url',
@@ -209,19 +209,19 @@ class FreeTreeClass {
         s.text = " $v";
       }
     });
-    
+
     scope.watchAST(treeRightNotNullAST, (v, _) {
       if (v != true) return;
       s.append(new SpanElement()
           ..append(new FreeTreeClass(scope, treeRightAST).element()));
     });
-    
+
     scope.watchAST(treeLeftNotNullAST, (v, _) {
       if (v != true) return;
       s.append(new SpanElement()
         ..append(new FreeTreeClass(scope, treeLeftAST).element()));
     });
-    
+
     return elt;
   }
 }
@@ -264,22 +264,28 @@ class NgFreeTreeClass implements ShadowRootAware {
 }
 
 
+class AppModule extends Module {
+  AppModule() {
+    bind(TreeComponent);
+    bind(TranscludingTreeComponent);
+    bind(TreeUrlComponent);
+    bind(TranscludingTreeUrlComponent);
+    bind(NgFreeTree);
+    bind(NgFreeTreeScoped);
+    bind(NgFreeTreeClass);
+    bind(ScopeDigestTTL, toFactory: () => new ScopeDigestTTL.value(15), inject: []);
+    bind(CompilerConfig, toValue: new CompilerConfig.withOptions(elementProbeEnabled: false));
+  }
+}
+
 // Main function runs the benchmark.
 main() {
   var cleanup, createDom;
 
-  var module = new Module()
-      ..bind(TreeComponent)
-      ..bind(TranscludingTreeComponent)
-      ..bind(TreeUrlComponent)
-      ..bind(TranscludingTreeUrlComponent)
-      ..bind(NgFreeTree)
-      ..bind(NgFreeTreeScoped)
-      ..bind(NgFreeTreeClass)
-      ..bind(ScopeDigestTTL, toFactory: () => new ScopeDigestTTL.value(15), inject: [])
-      ..bind(CompilerConfig, toValue: new CompilerConfig.withOptions(elementProbeEnabled: false));
+  var injector = applicationFactory()
+      .addModule(new AppModule())
+      .run();
 
-  var injector = applicationFactory().addModule(module).run();
   assert(injector != null);
 
   // Set up ASTs

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -18,7 +18,7 @@ packages:
   barback:
     description: barback
     source: hosted
-    version: "0.14.0+3"
+    version: "0.14.2"
   browser:
     description: browser
     source: hosted
@@ -34,7 +34,7 @@ packages:
   di:
     description: di
     source: hosted
-    version: "2.0.2"
+    version: "3.1.1"
   html5lib:
     description: html5lib
     source: hosted
@@ -42,7 +42,7 @@ packages:
   intl:
     description: intl
     source: hosted
-    version: "0.11.6"
+    version: "0.11.8"
   logging:
     description: logging
     source: hosted
@@ -59,6 +59,14 @@ packages:
     description: perf_api
     source: hosted
     version: "0.0.9"
+  petitparser:
+    description: petitparser
+    source: hosted
+    version: "1.2.2"
+  pool:
+    description: pool
+    source: hosted
+    version: "1.0.1"
   quiver:
     description: quiver
     source: hosted
@@ -78,7 +86,7 @@ packages:
   stack_trace:
     description: stack_trace
     source: hosted
-    version: "0.9.3+2"
+    version: "1.0.2"
   typed_mock:
     description: typed_mock
     source: hosted
@@ -94,4 +102,4 @@ packages:
   web_components:
     description: web_components
     source: hosted
-    version: "0.6.0+1"
+    version: "0.7.0+1"

--- a/lib/change_detection/dirty_checking_change_detector_dynamic.dart
+++ b/lib/change_detection/dirty_checking_change_detector_dynamic.dart
@@ -3,6 +3,7 @@ library dirty_checking_change_detector_dynamic;
 import 'package:angular/change_detection/change_detection.dart';
 export 'package:angular/change_detection/change_detection.dart' show
     FieldGetterFactory;
+import 'package:di/annotations.dart';
 
 /**
  * We are using mirrors, but there is no need to import anything.
@@ -10,6 +11,7 @@ export 'package:angular/change_detection/change_detection.dart' show
 @MirrorsUsed(targets: const [ DynamicFieldGetterFactory ], metaTargets: const [] )
 import 'dart:mirrors';
 
+@Injectable()
 class DynamicFieldGetterFactory implements FieldGetterFactory {
   FieldGetter getter(Object object, String name) {
     Symbol symbol = new Symbol(name);

--- a/lib/core/annotation_src.dart
+++ b/lib/core/annotation_src.dart
@@ -1,6 +1,7 @@
 library angular.core.annotation_src;
 
 import "package:di/di.dart" show Injector, Visibility, Factory;
+import "package:di/annotations.dart" show Injectable;
 
 abstract class DirectiveBinder {
  void bind(key, {dynamic toValue,
@@ -32,7 +33,7 @@ class Visibility {
 /**
  * Abstract supper class of [Component], and [Decorator].
  */
-abstract class Directive {
+abstract class Directive implements Injectable {
 
   /// The directive can only be injected to other directives on the same element.
   @Deprecated('Use Visibility.LOCAL instead')
@@ -485,7 +486,7 @@ abstract class DetachAware {
  *     <!-- Usage -->
  *     <span>{{something | myFormatter:arg1:arg2}}</span>
  */
-class Formatter {
+class Formatter implements Injectable {
   final String name;
 
   const Formatter({this.name});

--- a/lib/core/parser/dynamic_closure_map.dart
+++ b/lib/core/parser/dynamic_closure_map.dart
@@ -3,7 +3,9 @@ library angular.core.dynamic_closure_map;
 @MirrorsUsed(targets: const [ DynamicClosureMap ], metaTargets: const [] )
 import 'dart:mirrors';
 import 'package:angular/core/parser/parser.dart';
+import 'package:di/annotations.dart';
 
+@Injectable()
 class DynamicClosureMap implements ClosureMap {
   final Map<String, Symbol> symbols = {};
   Getter lookupGetter(String name) {

--- a/lib/core/registry_dynamic.dart
+++ b/lib/core/registry_dynamic.dart
@@ -1,15 +1,17 @@
 library angular.core_dynamic;
 
 import 'dart:mirrors';
+import 'dart:collection';
 import 'package:angular/core/annotation_src.dart';
 import 'package:angular/core/registry.dart';
-import 'dart:collection';
+import 'package:di/annotations.dart';
 
 export 'package:angular/core/registry.dart' show
     MetadataExtractor;
 
 var _fieldMetadataCache = new HashMap<Type, Map<String, DirectiveAnnotation>>();
 
+@Injectable()
 class DynamicMetadataExtractor implements MetadataExtractor {
   final _fieldAnnotations = [
         reflectType(NgAttr),

--- a/lib/core/zone.dart
+++ b/lib/core/zone.dart
@@ -53,6 +53,7 @@ class LongStackTrace {
  * runs the Angular digest.  A component may want to inject this singleton if it
  * needs to run code _outside_ the Angular digest.
  */
+@Injectable()
 class VmTurnZone {
   /// an "outer" [Zone], which is the one that created this.
   async.Zone _outerZone;

--- a/lib/core_dom/type_to_uri_mapper_dynamic.dart
+++ b/lib/core_dom/type_to_uri_mapper_dynamic.dart
@@ -2,10 +2,12 @@ library angular.core_dom.type_to_uri_mapper_dynamic;
 
 import 'dart:html' as dom;
 import 'dart:mirrors';
+import 'package:di/annotations.dart';
 
 import 'type_to_uri_mapper.dart';
 
 /// Resolves type-relative URIs
+@Injectable()
 class DynamicTypeToUriMapper extends TypeToUriMapper {
   Uri uriForType(Type type) {
     var typeMirror = reflectType(type);

--- a/lib/mock/exception_handler.dart
+++ b/lib/mock/exception_handler.dart
@@ -3,6 +3,7 @@ part of angular.mock;
 /**
  * Mock implementation of [ExceptionHandler] that rethrows exceptions.
  */
+@Injectable()
 class RethrowExceptionHandler extends ExceptionHandler {
   call(error, stack, [reason]){
     throw "$error $reason \nORIGINAL STACKTRACE:\n $stack";
@@ -20,6 +21,7 @@ class ExceptionWithStack {
  * Mock implementation of [ExceptionHandler] that logs all exceptions for
  * later processing.
  */
+@Injectable()
 class LoggingExceptionHandler implements ExceptionHandler {
   /**
    * All exceptions are stored here for later examining.

--- a/lib/mock/http_backend.dart
+++ b/lib/mock/http_backend.dart
@@ -139,6 +139,7 @@ bool _matchUrl(expected, actual) =>
 /**
  * A mock implementation of [HttpBackend], used in tests.
  */
+@Injectable()
 class MockHttpBackend implements HttpBackend {
   var definitions = [],
       expectations = [],

--- a/lib/mock/log.dart
+++ b/lib/mock/log.dart
@@ -36,6 +36,7 @@ class LogAttrDirective implements AttachAware {
  *
  *     expect(logger).toEqual(['foo', 'bar']);
  */
+@Injectable()
 class Logger extends ListBase {
   final tokens = [];
 

--- a/lib/mock/mock_cache_register.dart
+++ b/lib/mock/mock_cache_register.dart
@@ -3,6 +3,7 @@ part of angular.mock;
 /**
  * This is a null implementation of CacheRegister used in tests.
  */
+@Injectable()
 class MockCacheRegister implements CacheRegister {
   void registerCache(String name, cache) {}
   List<CacheRegisterStats> get stats {}

--- a/lib/mock/mock_platform_shim.dart
+++ b/lib/mock/mock_platform_shim.dart
@@ -5,6 +5,7 @@ part of angular.mock;
  * do not wish to take browser variance into account. This mock provides null
  * implementations of all operations, but they can be overwritten if needed.
  */
+@Injectable()
 class MockWebPlatformShim implements PlatformJsBasedShim, DefaultPlatformShim {
   bool shimRequired = false;
 

--- a/lib/mock/mock_window.dart
+++ b/lib/mock/mock_window.dart
@@ -1,6 +1,7 @@
 part of angular.mock;
 
 @proxy
+@Injectable()
 class MockWindow extends Mock implements Window {
   final history = new MockHistory();
   final location = new MockLocation();
@@ -16,13 +17,13 @@ class MockWindow extends Mock implements Window {
   dart_async.Stream<Event> get onHashChange => onHashChangeController.stream;
   dart_async.Stream<Event> get onClick => onClickController.stream;
   dart_async.Future<num> get animationFrame => animationFrameCompleter.future;
-  
+
   executeAnimationFrame([num time=0.0]) {
     var last = animationFrameCompleter;
     animationFrameCompleter = new dart_async.Completer<num>();
     last.complete(time);
   }
-      
+
   noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 

--- a/lib/mock/test_bed.dart
+++ b/lib/mock/test_bed.dart
@@ -6,6 +6,7 @@ part of angular.mock;
  * Simply inject [TestBed] into the test, then use [compile] to
  * match directives against the view.
  */
+@Injectable()
 class TestBed {
   final Injector injector;
   final Scope rootScope;

--- a/lib/tools/parser_getter_setter/generator.dart
+++ b/lib/tools/parser_getter_setter/generator.dart
@@ -1,6 +1,8 @@
 import 'package:angular/core/parser/parser.dart';
 import 'package:angular/utils.dart' show isReservedWord;
+import 'package:di/annotations.dart';
 
+@Injectable()
 class DartGetterSetterGen extends ParserBackend {
   final properties = new Set<String>();
   final calls = new Set<String>();
@@ -27,6 +29,7 @@ class DartGetterSetterGen extends ParserBackend {
       registerCall(name, arguments);
 }
 
+@Injectable()
 class ParserGetterSetter {
   final Parser parser;
   final ParserBackend backend;

--- a/lib/tools/transformer/expression_generator.dart
+++ b/lib/tools/transformer/expression_generator.dart
@@ -14,6 +14,7 @@ import 'package:angular/tools/transformer/referenced_uris.dart';
 import 'package:barback/barback.dart';
 import 'package:code_transformers/resolver.dart';
 import 'package:di/di.dart';
+import 'package:di/annotations.dart';
 import 'package:di/src/reflector_dynamic.dart';
 import 'package:path/path.dart' as path;
 
@@ -156,6 +157,7 @@ class _LibrarySourceCrawler implements SourceCrawler {
   }
 }
 
+@Injectable()
 class _ParserGetterSetter {
   final Parser parser;
   final ParserBackend backend;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -12,7 +12,7 @@ packages:
   barback:
     description: barback
     source: hosted
-    version: "0.14.1+3"
+    version: "0.14.2"
   benchmark_harness:
     description: benchmark_harness
     source: hosted
@@ -28,7 +28,7 @@ packages:
   code_transformers:
     description: code_transformers
     source: hosted
-    version: "0.1.5"
+    version: "0.1.6"
   collection:
     description: collection
     source: hosted
@@ -36,11 +36,11 @@ packages:
   di:
     description: di
     source: hosted
-    version: "2.0.1"
+    version: "3.1.1"
   guinness:
     description: guinness
     source: hosted
-    version: "0.1.9"
+    version: "0.1.15"
   html5lib:
     description: html5lib
     source: hosted
@@ -48,7 +48,7 @@ packages:
   intl:
     description: intl
     source: hosted
-    version: "0.8.10+4"
+    version: "0.11.8"
   js:
     description: js
     source: hosted
@@ -56,15 +56,11 @@ packages:
   logging:
     description: logging
     source: hosted
-    version: "0.9.1+1"
+    version: "0.9.2"
   matcher:
     description: matcher
     source: hosted
-    version: "0.11.0"
-  meta:
-    description: meta
-    source: hosted
-    version: "0.8.8"
+    version: "0.11.1"
   mock:
     description: mock
     source: hosted
@@ -72,11 +68,19 @@ packages:
   path:
     description: path
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   perf_api:
     description: perf_api
     source: hosted
     version: "0.0.9"
+  petitparser:
+    description: petitparser
+    source: hosted
+    version: "1.2.2"
+  pool:
+    description: pool
+    source: hosted
+    version: "1.0.1"
   protractor:
     description: protractor
     source: hosted
@@ -88,7 +92,7 @@ packages:
   source_maps:
     description: source_maps
     source: hosted
-    version: "0.9.3"
+    version: "0.9.4"
   source_span:
     description: source_span
     source: hosted
@@ -104,11 +108,11 @@ packages:
   unittest:
     description: unittest
     source: hosted
-    version: "0.11.0+3"
+    version: "0.11.0+5"
   utf:
     description: utf
     source: hosted
-    version: "0.9.0"
+    version: "0.9.0+1"
   web_components:
     description: web_components
     source: hosted

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   browser: '>=0.10.0 <0.11.0'
   code_transformers: '>=0.1.4+2 <0.2.0'
   collection: '>=0.9.1 <1.0.0'
-  di: '>=2.0.1 <3.0.0'
+  di: '>=3.1.1 <4.0.0'
   html5lib: '>=0.10.0 <0.11.0'
   intl: '>=0.8.7 <0.12.0'
   perf_api: '>=0.0.9 <0.1.0'

--- a/test/core/core_directive_spec.dart
+++ b/test/core/core_directive_spec.dart
@@ -41,8 +41,7 @@ void main() {
       beforeEach(() {
         baseModule = new Module()
           ..bind(DirectiveMap)
-          ..bind(DirectiveSelectorFactory)
-          ..bind(MetadataExtractor);
+          ..bind(DirectiveSelectorFactory);
       });
 
       it('should throw when annotation is for existing mapping', () {
@@ -170,6 +169,7 @@ class Sub extends Base {
   String bar;
 }
 
+@Injectable()
 class Base {
   @NgOneWay('baz')
   String baz;

--- a/test/core/scope_spec.dart
+++ b/test/core/scope_spec.dart
@@ -11,7 +11,6 @@ void main() {
     beforeEachModule((Module module) {
       Map context = {};
       module
-          ..bind(ChangeDetector, toImplementation: DirtyCheckingChangeDetector)
           ..bind(Object, toValue: context)
           ..bind(Map, toValue: context)
           ..bind(RootScope)
@@ -1761,6 +1760,7 @@ class FormatterTwo {
   }
 }
 
+@Injectable()
 class MockScopeStatsEmitter implements ScopeStatsEmitter {
   bool invoked = false;
 

--- a/test/core/templateurl_spec.dart
+++ b/test/core/templateurl_spec.dart
@@ -5,6 +5,7 @@ import 'package:angular/core_dom/type_to_uri_mapper.dart';
 import 'package:angular/core_dom/type_to_uri_mapper_dynamic.dart';
 import 'package:angular/core_dom/resource_url_resolver.dart';
 
+@Injectable()
 class StaticTypeToUriMapper extends TypeToUriMapper {
   DynamicTypeToUriMapper dynamicMapper;
 
@@ -60,6 +61,7 @@ class _ShadowComponentWithTranscludingComponent {
 }
 
 
+@Injectable()
 class PrefixedUrlRewriter extends UrlRewriter {
   call(url) => "PREFIX:$url";
 }

--- a/test/core_dom/compiler_spec.dart
+++ b/test/core_dom/compiler_spec.dart
@@ -1130,6 +1130,7 @@ class LazyPane {
   }
 }
 
+@Injectable()
 class LazyPaneHelper {}
 
 @Component(selector: 'pane')

--- a/test/core_dom/directive_injector_spec.dart
+++ b/test/core_dom/directive_injector_spec.dart
@@ -228,25 +228,44 @@ var _CHILDREN = new Key(_Local);
 var _LOCAL = new Key(_Local);
 var _TYPE0 = new Key(_Local);
 
+@Injectable()
 class _Children{}
+@Injectable()
 class _Local{}
+@Injectable()
 class _Direct{}
+@Injectable()
 class _Any{}
+@Injectable()
 class _Root{ }
+@Injectable()
 class _Type0{ final _Root root;   _Type0(this.root); }
+@Injectable()
 class _Type1{ final _Type0 type0; _Type1(this.type0); }
+@Injectable()
 class _Type2{ final _Type1 type1; _Type2(this.type1); }
+@Injectable()
 class _Type3{ final _Type2 type2; _Type3(this.type2); }
+@Injectable()
 class _Type4{ final _Type3 type3; _Type4(this.type3); }
+@Injectable()
 class _Type5{ final _Type4 type4; _Type5(this.type4); }
+@Injectable()
 class _Type6{ final _Type5 type5; _Type6(this.type5); }
+@Injectable()
 class _Type7{ final _Type6 type6; _Type7(this.type6); }
+@Injectable()
 class _Type8{ final _Type7 type7; _Type8(this.type7); }
+@Injectable()
 class _Type9{ final _Type8 type8; _Type9(this.type8); }
+@Injectable()
 class _TypeA{ final _Type9 type9; _TypeA(this.type9); }
 
+@Injectable()
 class _TypeC0 {final _TypeC1 t; _TypeC0(this.t);}
+@Injectable()
 class _TypeC1 {final _TypeC2 t; _TypeC1(this.t);}
+@Injectable()
 class _TypeC2 {final _TypeC1 t; _TypeC2(this.t);}
 
 class _InvalidVisibility {}

--- a/test/core_dom/http_spec.dart
+++ b/test/core_dom/http_spec.dart
@@ -14,6 +14,7 @@ class FakeCache extends UnboundedCache<String, HttpResponse> {
   int get length => 0;
 }
 
+@Injectable()
 class SubstringRewriter extends UrlRewriter {
   call(String x) => x.substring(0, 1);
 }

--- a/test/core_dom/view_spec.dart
+++ b/test/core_dom/view_spec.dart
@@ -4,6 +4,7 @@ import '../_specs.dart';
 import 'package:angular/application_factory.dart';
 import 'package:angular/core_dom/static_keys.dart';
 
+@Injectable()
 class Log {
   List<String> log = <String>[];
 

--- a/test/routing/ng_bind_route_spec.dart
+++ b/test/routing/ng_bind_route_spec.dart
@@ -52,6 +52,7 @@ main() {
   });
 }
 
+@Injectable()
 class NestedRouteInitializer implements Function {
   void call(Router router, RouteViewFactory views) {
     views.configure({

--- a/test/routing/ng_view_spec.dart
+++ b/test/routing/ng_view_spec.dart
@@ -191,6 +191,7 @@ main() => describe('ngView', () {
   });
 });
 
+@Injectable()
 class FlatRouteInitializer implements Function {
   void call(Router router, RouteViewFactory views) {
     views.configure({
@@ -201,6 +202,7 @@ class FlatRouteInitializer implements Function {
   }
 }
 
+@Injectable()
 class NestedRouteInitializer implements Function {
   void call(Router router, RouteViewFactory views) {
     views.configure({

--- a/test/routing/routing_spec.dart
+++ b/test/routing/routing_spec.dart
@@ -485,6 +485,7 @@ class MyDirective {
   }
 }
 
+@Injectable()
 class MyService {}
 
 @Formatter(name:'hello')


### PR DESCRIPTION
**Commit comment**

```
This is a breaking change: all classes that are instantiated via the DI
should be annotated (with one of @Injectable, @Component, @Decorator or
@Formatter).

Before this PR, the annotation were not enforced and the code could
break while switching to the static version of the DI because of a
missing annotation.

The impact on user code should be very limited as non-annotated classes
would not have worked before anyway. The error message is now clearer.

**Notes**

A side effect of this PR is that classes that were used only via the dynamic injector (during tests) should now have the `@Injectable` annotation.

While this is something we could change by updating the DI, I actually find the code clearer because it becomes easier to know which class might get injected.
```
