### PR TITLE
Add support for `()` syntax

### DIFF
--- a/lib/core/annotation.dart
+++ b/lib/core/annotation.dart
@@ -24,7 +24,9 @@ export "package:angular/core/annotation_src.dart" show
     NgCallback,
     NgOneWay,
     NgOneWayOneTime,
-    NgTwoWay;
+    NgTwoWay,
+
+    EventEmitter;
 
 
 /**

--- a/lib/core/annotation_src.dart
+++ b/lib/core/annotation_src.dart
@@ -492,3 +492,10 @@ class Formatter {
 
   String toString() => 'Formatter: $name';
 }
+
+/**
+ * Use the @[EventEmitter] class annotation to inject event emitters into a component.
+ */
+class EventEmitter {
+  const EventEmitter();
+}

--- a/lib/core_dom/element_binder.dart
+++ b/lib/core_dom/element_binder.dart
@@ -37,7 +37,7 @@ class ElementBinder {
   final Injector _appInjector;
   Animate _animate;
 
-  final Map onEvents;
+  final List<EventAttribute> onEvents;
   final Map bindAttrs;
 
   // Member fields
@@ -257,9 +257,8 @@ class ElementBinder {
       new AttrMustache(nodeAttrs, ref.value, ref.valueAST, nodeInjector.scope);
     } else if (ref.annotation is Component) {
       assert(ref == componentData.ref);
-
       BoundComponentFactory boundComponentFactory = componentData.factory;
-      Function componentFactory = boundComponentFactory.call(node);
+      Function componentFactory = boundComponentFactory.call(node, onEvents);
       nodeInjector.bindByKey(ref.typeKey, componentFactory,
           boundComponentFactory.callArgs, ref.annotation.visibility);
     } else {
@@ -333,7 +332,7 @@ class ElementBinder {
     }
 
     if (onEvents.isNotEmpty) {
-      onEvents.forEach((event, value) {
+      onEvents.forEach((event) {
         parentEventHandler.register(event);
       });
     }

--- a/lib/core_dom/element_binder.dart
+++ b/lib/core_dom/element_binder.dart
@@ -334,7 +334,7 @@ class ElementBinder {
 
     if (onEvents.isNotEmpty) {
       onEvents.forEach((event, value) {
-        parentEventHandler.register(EventHandler.attrNameToEventName(event));
+        parentEventHandler.register(event);
       });
     }
     return nodeInjector;

--- a/lib/core_dom/element_binder_builder.dart
+++ b/lib/core_dom/element_binder_builder.dart
@@ -41,7 +41,7 @@ class ElementBinderBuilder {
   final FormatterMap _formatters;
 
   /// "on-*" attribute names and values, added by a [DirectiveSelector]
-  final onEvents = new HashMap<String, String>();
+  final onEvents = new List<EventAttribute>();
   /// "bind-*" attribute names and values, added by a [DirectiveSelector]
   final bindAttrs = new HashMap<String, AST>();
 

--- a/lib/core_dom/event_handler.dart
+++ b/lib/core_dom/event_handler.dart
@@ -51,12 +51,13 @@ class EventHandler {
     dom.Node element = event.target;
     while (element != null && element != _rootNode) {
       var expression;
-      if (element is dom.Element)
-        expression = (element as dom.Element).attributes[eventNameToAttrName(event.type)];
+      if (element is dom.Element) {
+        expression = _readEventAttribute(element, event.type);
+      }
       if (expression != null) {
         try {
           var scope = _getScope(element);
-          if (scope != null) scope.eval(expression);
+          if (scope != null) scope.eval(expression, {"event" : event});
         } catch (e, s) {
           _exceptionHandler(e, s);
         }
@@ -77,6 +78,12 @@ class EventHandler {
     return null;
   }
 
+  String _readEventAttribute(dom.Element element, String eventType) {
+    var attr = element.attributes["on-$eventType"];
+    if (attr != null) return attr;
+    return element.attributes["(^$eventType)"];
+  }
+
   /**
   * Converts event name into attribute name.
   */
@@ -86,9 +93,20 @@ class EventHandler {
   * Converts attribute name into event name.
   */
   static String attrNameToEventName(String attrName) {
-    assert(attrName.startsWith('on-'));
-    return attrName.substring(3);
+    if (attrName.startsWith('on-')) {
+      return attrName.substring(3);
+    } else if (attrName.startsWith("(^") && attrName.endsWith(")")) {
+      return attrName.substring(2, attrName.length - 1);
+    } else {
+      throw "Invalid attribute name";
+    }
   }
+
+  /**
+   * Returns true if an attribute is an event, i.e., it starts with `on-` or `(^.`
+   */
+  static bool isEventAttribute(String attrName) =>
+      attrName.startsWith('on-') || (attrName.startsWith("(^") && attrName.endsWith(")"));
 }
 
 @Injectable()

--- a/lib/core_dom/event_handler.dart
+++ b/lib/core_dom/event_handler.dart
@@ -39,10 +39,10 @@ class EventHandler {
    * Register an event. This makes sure that  an event (of the specified name)
    * which bubbles to this node, gets processed by this [EventHandler].
    */
-  void register(String eventName) {
-    _listeners.putIfAbsent(eventName, () {
+  void register(EventAttribute eventAttr) {
+    _listeners.putIfAbsent(eventAttr.eventName, () {
       dom.EventListener eventListener = this._eventListener;
-      _rootNode.on[eventName].listen(eventListener);
+      _rootNode.on[eventAttr.eventName].listen(eventListener);
       return eventListener;
     });
   }
@@ -52,7 +52,7 @@ class EventHandler {
     while (element != null && element != _rootNode) {
       var expression;
       if (element is dom.Element) {
-        expression = _readEventAttribute(element, event.type);
+        expression = _readEventAttribute(element, event);
       }
       if (expression != null) {
         try {
@@ -78,35 +78,18 @@ class EventHandler {
     return null;
   }
 
-  String _readEventAttribute(dom.Element element, String eventType) {
-    var attr = element.attributes["on-$eventType"];
+  String _readEventAttribute(dom.Element element, dom.Event event) {
+    var attr = element.attributes["on-${event.type}"];
     if (attr != null) return attr;
-    return element.attributes["(^$eventType)"];
+
+    attr = element.attributes["(^${event.type})"];
+    if (attr != null) return attr;
+
+    attr = element.attributes["(${event.type})"];
+    if (attr != null && event.target == element) return attr;
+
+    return null;
   }
-
-  /**
-  * Converts event name into attribute name.
-  */
-  static String eventNameToAttrName(String eventName) => 'on-$eventName';
-
-  /**
-  * Converts attribute name into event name.
-  */
-  static String attrNameToEventName(String attrName) {
-    if (attrName.startsWith('on-')) {
-      return attrName.substring(3);
-    } else if (attrName.startsWith("(^") && attrName.endsWith(")")) {
-      return attrName.substring(2, attrName.length - 1);
-    } else {
-      throw "Invalid attribute name";
-    }
-  }
-
-  /**
-   * Returns true if an attribute is an event, i.e., it starts with `on-` or `(^.`
-   */
-  static bool isEventAttribute(String attrName) =>
-      attrName.startsWith('on-') || (attrName.startsWith("(^") && attrName.endsWith(")"));
 }
 
 @Injectable()

--- a/lib/core_dom/selector.dart
+++ b/lib/core_dom/selector.dart
@@ -89,8 +89,8 @@ class DirectiveSelector {
     // Select [attributes]
     element.attributes.forEach((attrName, value) {
 
-      if (attrName.startsWith("on-")) {
-        builder.onEvents[attrName] = value;
+      if (EventHandler.isEventAttribute(attrName)) {
+        builder.onEvents[EventHandler.attrNameToEventName(attrName)] = value;
       } else if (attrName.startsWith(BIND_PREFIX)) {
         builder.bindAttrs[attrName.substring(BIND_PREFIX_LENGTH)] =
             _astParser(value, formatters: _formatters);

--- a/lib/core_dom/shadow_dom_component_factory.dart
+++ b/lib/core_dom/shadow_dom_component_factory.dart
@@ -9,7 +9,7 @@ abstract class ComponentFactory {
  */
 abstract class BoundComponentFactory {
   List<Key> get callArgs;
-  Function call(dom.Element element);
+  Function call(dom.Element element, List<EventAttribute> eventAttrs);
 
   static async.Future<ViewFactory> _viewFuture(
         Component component, ViewCache viewCache, DirectiveMap directives,
@@ -94,7 +94,7 @@ class BoundShadowDomComponentFactory implements BoundComponentFactory {
   List<Key> get callArgs => _CALL_ARGS;
   static final _CALL_ARGS = [DIRECTIVE_INJECTOR_KEY, SCOPE_KEY, VIEW_KEY, NG_BASE_CSS_KEY,
       SHADOW_BOUNDARY_KEY];
-  Function call(dom.Element element) {
+  Function call(dom.Element element, List<EventAttribute> eventAttrs) {
     return (DirectiveInjector injector, Scope scope, View view, NgBaseCss baseCss,
         ShadowBoundary parentShadowBoundary) {
       var s = traceEnter(View_createComponent);
@@ -134,7 +134,7 @@ class BoundShadowDomComponentFactory implements BoundComponentFactory {
         var eventHandler = new ShadowRootEventHandler(
             shadowDom, injector.getByKey(EXPANDO_KEY), injector.getByKey(EXCEPTION_HANDLER_KEY));
         shadowInjector = new ComponentDirectiveInjector(injector, _injector, eventHandler, shadowScope,
-            templateLoader, shadowDom, null, view, shadowBoundary);
+            templateLoader, shadowDom, null, view, shadowBoundary, eventAttrs);
 
 
         shadowInjector.bindByKey(_ref.typeKey, _ref.factory, _ref.paramKeys, _ref.annotation.visibility);

--- a/lib/core_dom/transcluding_component_factory.dart
+++ b/lib/core_dom/transcluding_component_factory.dart
@@ -60,7 +60,7 @@ class BoundTranscludingComponentFactory implements BoundComponentFactory {
                             VIEW_CACHE_KEY, HTTP_KEY, TEMPLATE_CACHE_KEY,
                             DIRECTIVE_MAP_KEY, NG_BASE_CSS_KEY, EVENT_HANDLER_KEY,
                             SHADOW_BOUNDARY_KEY];
-  Function call(dom.Node node) {
+  Function call(dom.Node node, List<EventAttribute> eventAttrs) {
     var element = node as dom.Element;
     return (DirectiveInjector injector, Scope scope, View view,
             ViewCache viewCache, Http http, TemplateCache templateCache,
@@ -104,7 +104,7 @@ class BoundTranscludingComponentFactory implements BoundComponentFactory {
       Scope shadowScope = scope.createChild(new HashMap());
 
       childInjector = new ComponentDirectiveInjector(injector, this._injector,
-          eventHandler, shadowScope, templateLoader, shadowRoot, lightDom, view);
+          eventHandler, shadowScope, templateLoader, shadowRoot, lightDom, view, null, eventAttrs);
 
       childInjector.bindByKey(_ref.typeKey, _ref.factory, _ref.paramKeys, _ref.annotation.visibility);
 

--- a/test/angular_spec.dart
+++ b/test/angular_spec.dart
@@ -93,6 +93,7 @@ main() {
         "angular.core.annotation_src.DirectiveAnnotation",
         "angular.core.annotation_src.DirectiveBinder",
         "angular.core.annotation_src.DirectiveBinderFn",
+        "angular.core.annotation_src.EventEmitter",
         "angular.core.annotation_src.Formatter",
         "angular.core.annotation_src.NgAttr",
         "angular.core.annotation_src.NgCallback",

--- a/test/core_dom/compiler_spec.dart
+++ b/test/core_dom/compiler_spec.dart
@@ -1007,8 +1007,27 @@ void main() {
           _.rootScope.apply();
           expect(logger).toEqual([1, null, 8]);
         });
+      });
 
+      describe("event emitter", () {
+        beforeEachModule((Module module) {
+          module.bind(_CaptureEventComponent);
+          module.bind(EventComponent);
+        });
 
+        it("should invoke the event handler", async((_CaptureEventComponent c) {
+          _.compile('<event-comp (change)="invoked=event;"></event-comp>');
+
+          c.component.emitChange("EVENT");
+
+          expect(_.rootScope.context["invoked"]).toEqual("EVENT");
+        }));
+
+        it("should do nothing when no event handler", async((_CaptureEventComponent c) {
+          _.compile('<event-comp (change)="invoked=event;"></event-comp>');
+
+          c.component.emitChange("EVENT");
+        }));
       });
     });
 
@@ -1644,6 +1663,23 @@ class InnerInnerComponent {
     templateUrl: 'template.html'
 )
 class TemplateUrlComponent {
+}
+
+
+class _CaptureEventComponent {
+  EventComponent component;
+}
+
+@Component(
+    selector: 'event-comp',
+    template: ''
+)
+class EventComponent {
+  final Function emitChange;
+
+  EventComponent(@EventEmitter() this.emitChange, _CaptureEventComponent cmp) {
+    cmp.component = this;
+  }
 }
 
 _shadowScope(element){

--- a/test/core_dom/event_handler_spec.dart
+++ b/test/core_dom/event_handler_spec.dart
@@ -38,9 +38,25 @@ main() {
       return ngAppElement.firstChild;
     }
 
-    it('should register and handle event', (TestBed _) {
+    it('should register and handle event using on-* syntax', (TestBed _) {
       var e = compile(_,
         '''<div on-abc="invoked=true;"></div>''');
+
+      _.triggerEvent(e, 'abc');
+      expect(_.rootScope.context['invoked']).toEqual(true);
+    });
+
+    it('should expose event', (TestBed _) {
+      var e = compile(_,
+        '''<div on-abc="storedEvent=event;"></div>''');
+
+      _.triggerEvent(e, 'abc', 'MouseEvent');
+      expect(_.rootScope.context['storedEvent']).toBeAnInstanceOf(MouseEvent);
+    });
+
+    it('should register and handle event using (^*) syntax', (TestBed _) {
+      var e = compile(_,
+        '''<div (^abc)="invoked=true;"></div>''');
 
       _.triggerEvent(e, 'abc');
       expect(_.rootScope.context['invoked']).toEqual(true);

--- a/test/core_dom/event_handler_spec.dart
+++ b/test/core_dom/event_handler_spec.dart
@@ -39,35 +39,50 @@ main() {
     }
 
     it('should register and handle event using on-* syntax', (TestBed _) {
-      var e = compile(_,
-        '''<div on-abc="invoked=true;"></div>''');
+      var e = compile(_, '''<div on-abc="invoked=true;"></div>''');
 
       _.triggerEvent(e, 'abc');
-      expect(_.rootScope.context['invoked']).toEqual(true);
+
+      expect(_.rootScope.context['invoked']).toBeTrue();
     });
 
     it('should expose event', (TestBed _) {
-      var e = compile(_,
-        '''<div on-abc="storedEvent=event;"></div>''');
+      var e = compile(_, '''<div on-abc="storedEvent=event;"></div>''');
 
       _.triggerEvent(e, 'abc', 'MouseEvent');
+
       expect(_.rootScope.context['storedEvent']).toBeAnInstanceOf(MouseEvent);
     });
 
     it('should register and handle event using (^*) syntax', (TestBed _) {
-      var e = compile(_,
-        '''<div (^abc)="invoked=true;"></div>''');
+      var e = compile(_, '''<div (^abc)="invoked=true;"></div>''');
 
       _.triggerEvent(e, 'abc');
-      expect(_.rootScope.context['invoked']).toEqual(true);
+
+      expect(_.rootScope.context['invoked']).toBeTrue();
+    });
+
+    it('should register and handle event using (*) syntax', (TestBed _) {
+      var e = compile(_, '''<div (abc)="invoked=true;"></div>''');
+
+      _.triggerEvent(e, 'abc');
+
+      expect(_.rootScope.context['invoked']).toBeTrue();
+    });
+
+    it('should call (*) event handlers only when the target is the element it self', (TestBed _) {
+      var e = compile(_, '''<div (abc)="invoked=true;"><span></span></div>''');
+
+      _.triggerEvent(e.querySelector("span"), 'abc');
+
+      expect(_.rootScope.context['invoked']).toBeNull();
     });
 
     it('shoud register and handle event with long name', (TestBed _) {
-      var e = compile(_,
-        '''<div on-my-new-event="invoked=true;"></div>''');
+      var e = compile(_, '''<div on-my-new-event="invoked=true;"></div>''');
 
       _.triggerEvent(e, 'my-new-event');
-      expect(_.rootScope.context['invoked']).toEqual(true);
+      expect(_.rootScope.context['invoked']).toBeTrue();
     });
 
     it('shoud have model updates applied correctly', (TestBed _) {

--- a/test/core_dom/selector_spec.dart
+++ b/test/core_dom/selector_spec.dart
@@ -209,7 +209,12 @@ main() {
 
       it('should collect on-* attributes', () {
         ElementBinder binder = selector(e('<input on-click="foo" on-blah="fad"></input>'));
-        expect(binder.onEvents).toEqual({'on-click': 'foo', 'on-blah': 'fad'});
+        expect(binder.onEvents).toEqual({'click': 'foo', 'blah': 'fad'});
+      });
+
+      it('should collect (^*) attributes', () {
+        ElementBinder binder = selector(e('<input (^click)="foo" (^blah)="fad"></input>'));
+        expect(binder.onEvents).toEqual({'click': 'foo', 'blah': 'fad'});
       });
 
       it('should collect bind-* attributes', () {

--- a/test/core_dom/selector_spec.dart
+++ b/test/core_dom/selector_spec.dart
@@ -209,12 +209,23 @@ main() {
 
       it('should collect on-* attributes', () {
         ElementBinder binder = selector(e('<input on-click="foo" on-blah="fad"></input>'));
-        expect(binder.onEvents).toEqual({'click': 'foo', 'blah': 'fad'});
+
+        expect(binder.onEvents).toContain(new EventAttribute('on-click', true, 'foo'));
+        expect(binder.onEvents).toContain(new EventAttribute('on-blah', true, 'fad'));
       });
 
       it('should collect (^*) attributes', () {
         ElementBinder binder = selector(e('<input (^click)="foo" (^blah)="fad"></input>'));
-        expect(binder.onEvents).toEqual({'click': 'foo', 'blah': 'fad'});
+
+        expect(binder.onEvents).toContain(new EventAttribute('on-click', true, 'foo'));
+        expect(binder.onEvents).toContain(new EventAttribute('on-blah', true, 'fad'));
+      });
+
+      it('should collect (*) attributes', () {
+        ElementBinder binder = selector(e('<input (click)="foo" (blah)="fad"></input>'));
+
+        expect(binder.onEvents).toContain(new EventAttribute('on-click', false, 'foo'));
+        expect(binder.onEvents).toContain(new EventAttribute('on-blah', false, 'fad'));
       });
 
       it('should collect bind-* attributes', () {


### PR DESCRIPTION
The `()` syntax can be used to register an event handler.

Example:

```
<tabs (change)="ctrl.onTabSelection(event)"></tabs>
```

* If tabs is a web component, then the change event is a DOM event that is triggered on the tabs element. So when using `()` we do not handle bubbling events. 
* If tabs is an Angular component, then the change event is a custom Angular event. It can be emitted using an event emitter function, which can be injected into a component.

```
class Tabs {
  Function emitChange;
  
  Tabs(@EventEmitter('change') this.emitChange);
}
```

Known Limitations

At the moment Angular components can only emit the change event. This is due to the limitations in DI. Once https://github.com/angular/di.dart/pull/180 makes it into DI and Angular, it is fairly trivial to add support for other events.

This PR depends on #1481.