### PR TITLE
feat(Template): Introduce the @Template annotation

### DIFF
--- a/lib/application_factory.dart
+++ b/lib/application_factory.dart
@@ -53,6 +53,7 @@ import 'dart:html';
 metaTargets: const [
     Injectable,
     Decorator,
+    Template,
     Component,
     Formatter
 ])

--- a/lib/core/annotation.dart
+++ b/lib/core/annotation.dart
@@ -17,6 +17,7 @@ export "package:angular/core/annotation_src.dart" show
     Directive,
     Component,
     Decorator,
+    Template,
     Visibility,
 
     DirectiveAnnotation,

--- a/lib/core/annotation_src.dart
+++ b/lib/core/annotation_src.dart
@@ -78,11 +78,14 @@ abstract class Directive {
    * Compile the child nodes of the element.  This is the default.
    */
   static const String COMPILE_CHILDREN = 'compile';
+
   /**
    * Compile the child nodes for transclusion and makes available
    * [BoundViewFactory], [ViewFactory] and [ViewPort] for injection.
    */
+  @Deprecated('next release. Use @Template instead')
   static const String TRANSCLUDE_CHILDREN = 'transclude';
+
   /**
    * Do not compile/visit the child nodes.  Angular markup on descendant nodes
    * will not be processed.
@@ -370,6 +373,48 @@ class Decorator extends Directive {
           exportExpressions: exportExpressions,
           exportExpressionAttrs: exportExpressionAttrs,
           updateBoundElementPropertiesOnEvents: updateBoundElementPropertiesOnEvents);
+}
+
+/**
+ * Annotation placed on a class which should act as a template.
+ *
+ * Angular directives are instantiated using dependency injection, and can
+ * ask for any injectable object in their constructor. Directives
+ * can also ask for other components or directives declared on the DOM element.
+ *
+ * Directives can implement [AttachAware], [DetachAware] and
+ * declare these optional methods:
+ *
+ * * `attach()` - Called on first [Scope.apply()].
+ * * `detach()` - Called on when owning scope is destroyed.
+ */
+// TODO(vicb) for now extends Decorator as we need to keep BC
+// Extends Directive when transclusion support is removed from Decorator
+class Template extends Decorator {
+  const Template({map,
+                  selector,
+                  DirectiveBinderFn module,
+                  visibility,
+                  exportExpressions,
+                  exportExpressionAttrs,
+                  updateBoundElementPropertiesOnEvents})
+      : super(selector: selector,
+              children: Directive.TRANSCLUDE_CHILDREN,
+              visibility: visibility,
+              map: map,
+              module: module,
+              exportExpressions: exportExpressions,
+              exportExpressionAttrs: exportExpressionAttrs,
+              updateBoundElementPropertiesOnEvents: updateBoundElementPropertiesOnEvents);
+
+  Template _cloneWithNewMap(newMap) =>
+      new Template(map: newMap,
+                   module: module,
+                   selector: selector,
+                   visibility: visibility,
+                   exportExpressions: exportExpressions,
+                   exportExpressionAttrs: exportExpressionAttrs,
+                   updateBoundElementPropertiesOnEvents: updateBoundElementPropertiesOnEvents);
 }
 
 /**

--- a/lib/core_dom/element_binder.dart
+++ b/lib/core_dom/element_binder.dart
@@ -124,13 +124,19 @@ class ElementBinder {
   }
 
 
-  void _createAttrMappings(directive, scope, List<MappingParts> mappings, nodeAttrs, tasks) {
+  void _createAttrMappings(directive, scope, DirectiveRef ref, nodeAttrs, tasks) {
     Scope directiveScope; // Only created if there is a two-way binding in the element.
+    List<MappingParts> mappings = ref.mappings;
+    // TODO(vicb): Change to `ref.annotation is Template` when former syntax is deprecated
+    var isTemplate = nodeAttrs is _AnchorAttrs;
+
     for(var i = 0; i < mappings.length; i++) {
       MappingParts p = mappings[i];
       var attrName = p.attrName;
       var attrValueAST = p.attrValueAST;
       AST dstAST = p.dstAST;
+
+      var attrValue = isTemplate ? ref.value : nodeAttrs[attrName];
 
       if (!dstAST.parsedExp.isAssignable) {
         throw "Expression '${dstAST.expression}' is not assignable in mapping '${p.originalValue}' "
@@ -157,14 +163,18 @@ class ElementBinder {
       switch (p.mode) {
         case '@': // string
           var taskId = (tasks != null) ? tasks.registerTask() : 0;
-          nodeAttrs.observe(attrName, (value) {
-            dstAST.parsedExp.assign(directive, value);
-            if (tasks != null) tasks.completeTask(taskId);
-          });
+          if (isTemplate) {
+            dstAST.parsedExp.assign(directive, attrValue);
+          } else {
+            nodeAttrs.observe(attrName, (value) {
+              dstAST.parsedExp.assign(directive, value);
+              if (tasks != null) tasks.completeTask(taskId);
+            });
+          }
           break;
 
         case '<=>': // two-way
-          if (nodeAttrs[attrName] == null) continue;
+          if (attrValue == null) continue;
           if (directiveScope == null) {
             directiveScope = scope.createChild(directive);
           }
@@ -173,12 +183,12 @@ class ElementBinder {
           break;
 
         case '=>': // one-way
-          if (nodeAttrs[attrName] == null) continue;
+          if (attrValue == null) continue;
           _bindOneWay(tasks, attrValueAST, scope, dstAST, directive);
           break;
 
         case '=>!': //  one-way, one-time
-          if (nodeAttrs[attrName] == null) continue;
+          if (attrValue == null) continue;
 
           var watch;
           var lastOneTimeValue;
@@ -198,7 +208,7 @@ class ElementBinder {
           break;
 
         case '&': // callback
-          _bindCallback(dstAST.parsedExp, directive, nodeAttrs[attrName], scope);
+          _bindCallback(dstAST.parsedExp, directive, attrValue, scope);
           break;
       }
     }
@@ -222,8 +232,9 @@ class ElementBinder {
         }) : null;
 
         if (ref.mappings.isNotEmpty) {
+          // TODO(vicb): remove when the '.' syntax is removed for Templates
           if (nodeAttrs == null) nodeAttrs = new _AnchorAttrs(ref);
-          _createAttrMappings(directive, scope, ref.mappings, nodeAttrs, tasks);
+          _createAttrMappings(directive, scope, ref, nodeAttrs, tasks);
         }
 
         if (directive is AttachAware) {

--- a/lib/core_dom/element_binder_builder.dart
+++ b/lib/core_dom/element_binder_builder.dart
@@ -105,7 +105,19 @@ class ElementBinderBuilder {
         // Look up the value of attrName and compute an AST
         AST ast;
         if (mode != '@' && mode != '&') {
-          var value = attrName == "." ? ref.value : (ref.element as dom.Element).attributes[attrName];
+          // todo(vicb) remove the "." special case when the "." syntax is removed
+          var value;
+          if (attrName == ".") {
+            value = ref.value;
+            print("DEPRECATION WARNING: The usage of '.' has been deprecated in the directive "
+                  "map for '${annotation.selector}', use the attribute name instead.");
+          } else {
+            // Saves a DOM read by getting the value from the `DirectiveRef` when possible
+            value = annotation.selector == '[$attrName]' ?
+                ref.value :
+                (ref.element as dom.Element).getAttribute(attrName);
+          }
+
           if (value == null || value.isEmpty) { value = "''"; }
           ast = _factory.astParser(value, formatters: _formatters);
         }

--- a/lib/core_dom/view_factory.dart
+++ b/lib/core_dom/view_factory.dart
@@ -239,6 +239,7 @@ class ViewCache {
   }
 }
 
+@Deprecated('next release')
 class _AnchorAttrs extends NodeAttrs {
   DirectiveRef _directiveRef;
 

--- a/lib/directive/ng_if.dart
+++ b/lib/directive/ng_if.dart
@@ -74,7 +74,7 @@ abstract class _NgUnlessIfAttrDirectiveBase {
  */
 @Template(
     selector:'[ng-if]',
-    map: const {'.': '=>condition'})
+    map: const {'ng-if': '=>condition'})
 class NgIf extends _NgUnlessIfAttrDirectiveBase {
   NgIf(ViewFactory viewFactory, ViewPort viewPort, Scope scope)
       : super(viewFactory, viewPort, scope);
@@ -133,7 +133,7 @@ class NgIf extends _NgUnlessIfAttrDirectiveBase {
  */
 @Template(
     selector:'[ng-unless]',
-    map: const {'.': '=>condition'})
+    map: const {'ng-unless': '=>condition'})
 class NgUnless extends _NgUnlessIfAttrDirectiveBase {
 
   NgUnless(ViewFactory viewFactory, ViewPort viewPort, Scope scope)

--- a/lib/directive/ng_if.dart
+++ b/lib/directive/ng_if.dart
@@ -72,8 +72,7 @@ abstract class _NgUnlessIfAttrDirectiveBase {
  *        </div>
  *     </div>
  */
-@Decorator(
-    children: Directive.TRANSCLUDE_CHILDREN,
+@Template(
     selector:'[ng-if]',
     map: const {'.': '=>condition'})
 class NgIf extends _NgUnlessIfAttrDirectiveBase {
@@ -132,8 +131,7 @@ class NgIf extends _NgUnlessIfAttrDirectiveBase {
  *        </div>
  *     </div>
  */
-@Decorator(
-    children: Directive.TRANSCLUDE_CHILDREN,
+@Template(
     selector:'[ng-unless]',
     map: const {'.': '=>condition'})
 class NgUnless extends _NgUnlessIfAttrDirectiveBase {

--- a/lib/directive/ng_repeat.dart
+++ b/lib/directive/ng_repeat.dart
@@ -67,7 +67,7 @@ part of angular.directive;
 
 @Template(
     selector: '[ng-repeat]',
-    map: const {'.': '@expression'})
+    map: const {'ng-repeat': '@expression'})
 class NgRepeat {
   static RegExp _SYNTAX = new RegExp(r'^\s*(.+)\s+in\s+(.*?)\s*(?:track\s+by\s+(.+)\s*)?(\s+lazily\s*)?$');
   static RegExp _LHS_SYNTAX = new RegExp(r'^(?:([$\w]+)|\(([$\w]+)\s*,\s*([$\w]+)\))$');

--- a/lib/directive/ng_repeat.dart
+++ b/lib/directive/ng_repeat.dart
@@ -65,8 +65,7 @@ part of angular.directive;
  *     </ul>
  */
 
-@Decorator(
-    children: Directive.TRANSCLUDE_CHILDREN,
+@Template(
     selector: '[ng-repeat]',
     map: const {'.': '@expression'})
 class NgRepeat {

--- a/lib/directive/ng_switch.dart
+++ b/lib/directive/ng_switch.dart
@@ -110,7 +110,7 @@ class _Case {
 
 @Template(
     selector: '[ng-switch-when]',
-    map: const {'.': '@value'})
+    map: const {'ng-switch-when': '@value'})
 class NgSwitchWhen {
   final NgSwitch ngSwitch;
   final ViewPort port;

--- a/lib/directive/ng_switch.dart
+++ b/lib/directive/ng_switch.dart
@@ -108,9 +108,8 @@ class _Case {
   _Case(this.anchor, this.viewFactory);
 }
 
-@Decorator(
+@Template(
     selector: '[ng-switch-when]',
-    children: Directive.TRANSCLUDE_CHILDREN,
     map: const {'.': '@value'})
 class NgSwitchWhen {
   final NgSwitch ngSwitch;
@@ -123,9 +122,7 @@ class NgSwitchWhen {
   set value(String value) => ngSwitch.addCase('!$value', port, viewFactory);
 }
 
-@Decorator(
-    children: Directive.TRANSCLUDE_CHILDREN,
-    selector: '[ng-switch-default]')
+@Template(selector: '[ng-switch-default]')
 class NgSwitchDefault {
 
   NgSwitchDefault(NgSwitch ngSwitch, ViewPort port,

--- a/lib/tools/source_metadata_extractor.dart
+++ b/lib/tools/source_metadata_extractor.dart
@@ -122,7 +122,8 @@ class DirectiveMetadataCollectingAstVisitor extends RecursiveAstVisitor {
       // annotations, but good enough for now.
       if (ann.name.name != 'Component' &&
           ann.name.name != 'Decorator' &&
-          ann.name.name != 'Controller') return;
+          ann.name.name != 'Controller' &&
+          ann.name.name != 'Template') return;
 
       var meta = new DirectiveMetadata()..className = clazz.name.name;
       metadata.add(meta);

--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -37,6 +37,7 @@ TransformOptions _parseSettings(Map args) {
       'di.annotations.Injectable',
       'angular.core.annotation_src.Decorator',
       'angular.core.annotation_src.Component',
+      'angular.core.annotation_src.Template',
       'angular.core.annotation_src.Formatter'];
   annotations.addAll(_readStringListValue(args, 'injectable_annotations'));
 

--- a/test/angular_spec.dart
+++ b/test/angular_spec.dart
@@ -41,7 +41,7 @@ main() {
       assertSymbolNamesAreOk(ALLOWED_NAMES, libraryInfo);
 
     });
-    
+
     it('should not export unknown symbols from touch', () {
       LibraryInfo libraryInfo;
       try {
@@ -99,6 +99,7 @@ main() {
         "angular.core.annotation_src.NgOneWay",
         "angular.core.annotation_src.NgOneWayOneTime",
         "angular.core.annotation_src.NgTwoWay",
+        "angular.core.annotation_src.Template",
         "angular.core.annotation_src.Visibility",
         "angular.core.dom_internal.Animate",
         "angular.core.dom_internal.Animation",

--- a/test/core/annotation_src_spec.dart
+++ b/test/core/annotation_src_spec.dart
@@ -41,7 +41,7 @@ void main() => describe('annotations', () {
         module: (i){},
         map: {},
         selector: '',
-        visibility: Directive.LOCAL_VISIBILITY,
+        visibility: Visibility.LOCAL,
         exportExpressions: [],
         exportExpressionAttrs: [],
         useShadowDom: true,
@@ -63,7 +63,7 @@ void main() => describe('annotations', () {
           map: {},
           selector: '',
           module: (i){},
-          visibility: Directive.LOCAL_VISIBILITY,
+          visibility: Visibility.LOCAL,
           exportExpressions: [],
           exportExpressionAttrs: [],
           updateBoundElementPropertiesOnEvents: []
@@ -74,6 +74,26 @@ void main() => describe('annotations', () {
 
       // Check that the clone is the same as the original.
       expect(variables(cloneWithNewMap(decorator, {}))).toEqual(variables(decorator));
+    });
+  });
+
+  describe('template', () {
+    it('should set all fields on clone when all the fields are set', () {
+      var template = new Template(
+          map: {},
+          selector: '',
+          module: (i){},
+          visibility: Visibility.LOCAL,
+          exportExpressions: [],
+          exportExpressionAttrs: [],
+          updateBoundElementPropertiesOnEvents: []
+      );
+
+      // Check that no fields are null
+      expect(nullFields(template)).toEqual([]);
+
+      // Check that the clone is the same as the original.
+      expect(variables(cloneWithNewMap(template, {}))).toEqual(variables(template));
     });
   });
 });

--- a/test/core_dom/compiler_spec.dart
+++ b/test/core_dom/compiler_spec.dart
@@ -1182,10 +1182,9 @@ class ChildTemplateComponent {
   ChildTemplateComponent() {}
 }
 
-@Decorator(
+@Template(
     selector: '[simple-transclude-in-attach]',
-    visibility: Visibility.LOCAL,
-    children: Directive.TRANSCLUDE_CHILDREN)
+    visibility: Visibility.LOCAL)
 class SimpleTranscludeInAttachAttrDirective {
   SimpleTranscludeInAttachAttrDirective(ViewPort viewPort, BoundViewFactory boundViewFactory, Logger log, RootScope scope) {
     scope.runAsync(() {
@@ -1520,9 +1519,8 @@ class OneTimeDecorator {
   set value(v) => log(v);
 }
 
-@Decorator(
+@Template(
   selector: '[same-name]',
-  children: Directive.TRANSCLUDE_CHILDREN,
   map: const { '.': '@valueTransclude' }
 )
 class SameNameTransclude {

--- a/test/core_dom/element_binder_builder_spec.dart
+++ b/test/core_dom/element_binder_builder_spec.dart
@@ -3,14 +3,11 @@ library angular.dom.element_binder_spec;
 import '../_specs.dart';
 import 'dart:mirrors';
 
-@Component(selector:'component')            class _Component{}
+@Component(selector:'component')                 class _Component{}
 @Decorator(selector:'[ignore-children]',
-             children: Directive.IGNORE_CHILDREN)
-                                              class _IgnoreChildren{}
-@Decorator(selector:'[structural]',
-             children: Directive.TRANSCLUDE_CHILDREN)
-                                              class _Structural{}
-@Decorator(selector:'[directive]')          class _DirectiveAttr{}
+           children: Directive.IGNORE_CHILDREN)  class _IgnoreChildren{}
+@Template(selector:'[structural]')               class _Structural{}
+@Decorator(selector:'[directive]')               class _DirectiveAttr{}
 
 
 directiveFor(i) {

--- a/test/core_dom/selector_spec.dart
+++ b/test/core_dom/selector_spec.dart
@@ -2,7 +2,7 @@ library angular.dom.selector_spec;
 
 import '../_specs.dart';
 
-const _aBElement               = const Decorator(selector:'b'); 
+const _aBElement               = const Decorator(selector:'b');
 const _aBClass                 = const Decorator(selector:'.b');
 const _aDirectiveAttr          = const Decorator(selector:'[directive]');
 const _aWildcardDirectiveAttr  = const Decorator(selector:'[wildcard-*]');
@@ -14,8 +14,7 @@ const _aContainsAbc            = const Decorator(selector:':contains(/abc/)');
 const _aAttributeContainsXyz   = const Decorator(selector:'[*=/xyz/]');
 const _aAttribute              = const Decorator(selector:'[attribute]');
 const _aCComponent             = const Component(selector:'component');
-const _aStructural             = const Decorator(selector:'[structural]',
-                                                 children: Directive.TRANSCLUDE_CHILDREN);
+const _aStructural             = const Template(selector:'[structural]');
 const _aIgnoreChildren         = const Decorator(selector:'[ignore-children]',
                                                  children: Directive.IGNORE_CHILDREN);
 const _aTwoDirectives0         = const Decorator(selector: '[my-model][required]');

--- a/test/core_dom/view_spec.dart
+++ b/test/core_dom/view_spec.dart
@@ -10,7 +10,7 @@ class Log {
   add(String msg) => log.add(msg);
 }
 
-@Decorator(children: Directive.TRANSCLUDE_CHILDREN, selector: 'foo')
+@Template(selector: 'foo')
 class LoggerViewDirective {
   LoggerViewDirective(ViewPort port, ViewFactory viewFactory,
       BoundViewFactory boundViewFactory, Logger logger) {
@@ -166,7 +166,7 @@ main() {
 
           var directiveRef = new DirectiveRef(null,
                                               LoggerViewDirective,
-                                              new Decorator(children: Directive.TRANSCLUDE_CHILDREN, selector: 'foo'),
+                                              new Template(selector: 'foo'),
                                               '');
           directiveRef.viewFactory = viewFactoryFactory($('<b>text</b>'), [], perf, new Expando());
           var binder = ebf.binder();

--- a/test/directive/ng_if_spec.dart
+++ b/test/directive/ng_if_spec.dart
@@ -2,9 +2,7 @@ library ng_if_spec;
 
 import '../_specs.dart';
 
-@Decorator(
-    selector: '[child-controller]',
-    children: Directive.TRANSCLUDE_CHILDREN)
+@Template(selector: '[child-controller]')
 class ChildController {
   ChildController(BoundViewFactory boundViewFactory,
                   ViewPort viewPort,

--- a/test/io/test_files/main.dart
+++ b/test/io/test_files/main.dart
@@ -2,8 +2,7 @@ library test_files.main;
 
 import 'package:angular/core/annotation_src.dart';
 
-@Decorator(
-    children: Directive.TRANSCLUDE_CHILDREN,
+@Template(
     selector:'[ng-if]',
     map: const {'.': '=>ngIfCondition'})
 class NgIfDirective {


### PR DESCRIPTION
Transclusion syntax has changed (The former syntax is supported but will
be deprecated in the next release)

Before:

    @Decorator(
        selector: '[ng-if]',
        children: Directive.TRANSCLUDE_CHILDREN,
        map: const {'.': 'mapping'},
        <other kv pairs>)

After:

    @Template(
        selector: '[ng-if]',
        map: const {'.' : 'mapping'},
        <other kv pairs>)