### PR TITLE
Remove NG_VALID/ng-valid

### DIFF
--- a/lib/directive/ng_control.dart
+++ b/lib/directive/ng_control.dart
@@ -8,7 +8,6 @@ part of angular.directive;
  * user input with NgModel.
  */
 abstract class NgControl implements AttachAware, DetachAware {
-  static const NG_VALID          = "ng-valid";
   static const NG_INVALID        = "ng-invalid";
   static const NG_PRISTINE       = "ng-pristine";
   static const NG_DIRTY          = "ng-dirty";

--- a/test/directive/ng_form_spec.dart
+++ b/test/directive/ng_form_spec.dart
@@ -169,7 +169,6 @@ void main() {
         expect(form).not.toBeValid();
 
         expect(element).toHaveClass('ng-invalid');
-        expect(element).not.toHaveClass('ng-valid');
 
         model.removeError('some-error');
         model.validate();
@@ -177,7 +176,6 @@ void main() {
 
         expect(form).toBeValid();
         expect(element).not.toHaveClass('ng-invalid');
-        //expect(element).toHaveClass('ng-valid');
       });
 
       it('should set the validity with respect to all existing validations when error states are set is used', (Scope scope, TestBed _) {

--- a/test/directive/ng_model_spec.dart
+++ b/test/directive/ng_model_spec.dart
@@ -1259,7 +1259,6 @@ void main() {
 
         expect(model.valid).toEqual(false);
         expect(model.invalid).toEqual(true);
-        //expect(element).not.toHaveClass('ng-valid');
         expect(element).toHaveClass('ng-invalid');
 
         model.removeError('ng-required');
@@ -1269,7 +1268,6 @@ void main() {
         expect(model.valid).toEqual(true);
         expect(model.invalid).toEqual(false);
         expect(element).not.toHaveClass('ng-invalid');
-        // expect(element).toHaveClass('ng-valid');
       });
 
       it('should set the validity with respect to all existing validations when setValidity() is used', (Scope scope) {


### PR DESCRIPTION
The NG_VALID is never used. Likewise, the ng-valid css class is never set by NgControl/NgModel.

Its existence is confusing because a reader will think that ng-valid can be used to style fields that are valid.

Alternatively, NG_VALID could be added as opposite style to _getOppositeInfoState to be in sync with user expectations.
