### PR TITLE
feat(core, testability): PendingAsync service

### DIFF
--- a/lib/core/module.dart
+++ b/lib/core/module.dart
@@ -51,6 +51,7 @@ export "package:angular/core_dom/module_internal.dart" show
     NgElement,
     NoOpAnimation,
     NullTreeSanitizer,
+    PendingAsync,
     Animate,
     RequestErrorInterceptor,
     RequestInterceptor,

--- a/lib/core/module_internal.dart
+++ b/lib/core/module_internal.dart
@@ -26,6 +26,8 @@ export 'package:angular/core/formatter.dart';
 import 'package:angular/core/parser/utils.dart';
 import 'package:angular/core/registry.dart';
 import 'package:angular/core/static_keys.dart';
+import 'package:angular/core/pending_async.dart';
+export 'package:angular/core/pending_async.dart';
 
 part "exception_handler.dart";
 part "interpolate.dart";
@@ -41,6 +43,7 @@ class CoreModule extends Module {
     bind(FormatterMap);
     bind(Interpolate);
     bind(RootScope);
+    bind(PendingAsync);
     bind(Scope, toInstanceOf: RootScope);
     bind(ClosureMap, toFactory: () => throw "Must provide dynamic/static ClosureMap.");
     bind(ScopeStats);

--- a/lib/core/pending_async.dart
+++ b/lib/core/pending_async.dart
@@ -1,0 +1,68 @@
+library angular.core.pending_async;
+
+import 'dart:async';
+import 'package:di/annotations.dart';
+
+typedef void WhenStableCallback();
+
+/**
+ * Tracks pending operations and notifies when they are all complete.
+ */
+@Injectable()
+class PendingAsync {
+  /// a count of the number of pending async operations.
+  int _numPending = 0;
+  List<WhenStableCallback> _callbacks;
+
+  /**
+   * A count of the number of tracked pending async operations.
+   */
+  int get numPending => _numPending;
+
+  /**
+   * Register a callback to be called synchronously when the number of tracked
+   * pending async operations reaches a count of zero from a non-zero count.
+   */
+  void whenStable(WhenStableCallback cb) {
+    if (_numPending == 0) {
+      cb();
+      return;
+    }
+    if (_callbacks == null) {
+      _callbacks = <WhenStableCallback>[cb];
+    } else {
+      _callbacks.add(cb);
+    }
+  }
+
+  /**
+   * Increase the counter of the number of tracked pending operations.  Returns
+   * the new count of the number of tracked pending operations.
+   */
+  int increaseCount([int delta = 1]) {
+    if (delta == 0) {
+      return _numPending;
+    }
+    _numPending += delta;
+    if (_numPending < 0) {
+      throw "Attempting to reduce pending async count below zero.";
+    } else if (_numPending == 0) {
+      _runAllCallbacks();
+    }
+    return _numPending;
+  }
+
+  /**
+   * Decrease the counter of the number of tracked pending operations.  Returns
+   * the new count of the number of tracked pending operations.
+   */
+  int decreaseCount([int delta = 1]) => increaseCount(-delta);
+
+  void _runAllCallbacks() {
+    while (_callbacks != null) {
+      var callbacks = _callbacks;
+      _callbacks = null;
+      callbacks.forEach((fn) { fn(); });
+    }
+  }
+}

--- a/lib/introspection.dart
+++ b/lib/introspection.dart
@@ -264,12 +264,15 @@ typedef List<String> _GetExpressionsFromProbe(ElementProbe probe);
 class _Testability implements _JsObjectProxyable {
   final dom.Node node;
   final ElementProbe probe;
+  final PendingAsync _pendingAsync;
 
-  _Testability(this.node, this.probe);
+  _Testability(dom.Node node, ElementProbe probe):
+      node = node,
+      probe = probe,
+      _pendingAsync = probe.injector.get(PendingAsync);
 
   whenStable(callback) {
-    (probe.injector.get(VmTurnZone) as VmTurnZone).run(
-        () => new async.Timer(Duration.ZERO, callback));
+    _pendingAsync.whenStable(callback);
   }
 
   /**

--- a/lib/mock/module.dart
+++ b/lib/mock/module.dart
@@ -55,7 +55,7 @@ part 'mock_cache_register.dart';
  *   - [Logger]
  *   - [RethrowExceptionHandler] instead of [ExceptionHandler]
  *   - [VmTurnZone] which displays errors to console;
- *   - [MockCacheRegister
+ *   - [MockCacheRegister]
  */
 class AngularMockModule extends Module {
   AngularMockModule() {

--- a/lib/mock/zone.dart
+++ b/lib/mock/zone.dart
@@ -276,3 +276,15 @@ class _TimerSpec implements dart_async.Timer {
     isActive = false;
   }
 }
+
+
+class MockZone {
+  MockZone._internal();
+
+  MockZone get current => Zone.current['AngularMockZone'];
+
+  static Zone fork(Zone zone) {
+    MockZone mockZone = new MockZone._internal();
+    return zone.fork(zoneValues: { 'AngularMockZone': mockZone });
+  }
+}

--- a/lib/ng_tracing_scopes.dart
+++ b/lib/ng_tracing_scopes.dart
@@ -142,6 +142,14 @@ final VmTurnZone_scheduleMicrotask = traceCreateScope('VmTurnZone#scheduleMicrot
 
 
 /**
+ * Name: `VmTurnZone#createTimer()`
+ *
+ * Designates where new timers are scheduled.
+ */
+final VmTurnZone_createTimer = traceCreateScope('VmTurnZone#createTimer()');
+
+
+/**
  * Name: `Compiler#compile()`
  *
  * Designates where template HTML is compiled. Compilation is a process of walking the DOM and

--- a/test/core/pending_async_spec.dart
+++ b/test/core/pending_async_spec.dart
@@ -1,0 +1,75 @@
+library pending_async_spec;
+
+import '../_specs.dart';
+
+import 'dart:async';
+
+void main() {
+  describe('pending_async', () {
+    PendingAsync pendingAsync;
+    Logger log;
+    callbackLog(msg) => () { log(msg); };
+
+    beforeEachModule((Module module) {
+      module.bind(ExceptionHandler, toValue: new LoggingExceptionHandler());
+    });
+
+    beforeEach((Logger _log) {
+      log = _log;
+      pendingAsync = new PendingAsync();
+    });
+
+    it('should start with a pending count of 0', () {
+      expect(pendingAsync.numPending).toEqual(0);
+    });
+
+    it('should increase and return new pending count', () {
+      expect(pendingAsync.increaseCount(1)).toEqual(1);
+      expect(pendingAsync.increaseCount(1)).toEqual(2);
+      expect(pendingAsync.increaseCount(2)).toEqual(4);
+    });
+
+    it('should decrease and return new pending count', () {
+      pendingAsync.increaseCount(3);
+      expect(pendingAsync.increaseCount(-2)).toEqual(1);
+      expect(pendingAsync.decreaseCount(1)).toEqual(0);
+      expect(() => pendingAsync.decreaseCount(1)).toThrow();
+      pendingAsync.increaseCount(3);
+      expect(() => pendingAsync.decreaseCount(4)).toThrow();
+    });
+
+    describe('whenStable', () {
+      it('should fire callbacks when in initial stable state', async(() {
+        expect(pendingAsync.numPending).toEqual(0);
+        pendingAsync.whenStable(callbackLog('cb 1'));
+        expect(log.result()).toEqual('cb 1');
+      }));
+
+      it('should NOT fire callbacks when there are pending operations', async(() {
+        pendingAsync.increaseCount(2);
+        pendingAsync.whenStable(callbackLog('cb 2'));
+        expect(log.result()).toEqual('');
+        pendingAsync.decreaseCount(1);
+        expect(log.result()).toEqual('');
+      }));
+
+      it('should complete the future when there no pending operations left', async(() {
+        pendingAsync.increaseCount(2);
+        pendingAsync.whenStable(callbackLog('cb 3'));
+        expect(log.result()).toEqual('');
+        pendingAsync.decreaseCount(2);
+        expect(log.result()).toEqual('cb 3');
+      }));
+
+      it('should complete the future if already completed and still in a stable state', async(() {
+        pendingAsync.increaseCount(1);
+        pendingAsync.whenStable(callbackLog('cb 4'));
+        pendingAsync.decreaseCount(1);
+        expect(log.result()).toEqual('cb 4');
+        pendingAsync.whenStable(callbackLog('cb 5'));
+        expect(log.result()).toEqual('cb 4; cb 5');
+      }));
+    });
+
+  });
+}

--- a/test/core_dom/http_spec.dart
+++ b/test/core_dom/http_spec.dart
@@ -68,6 +68,21 @@ void main() {
         callback = guinness.createSpy('callback');
       });
 
+      describe('PendingAsync', () {
+        it('should register requests with PendingAsync', async((
+            Http http, PendingAsync pendingAsync) {
+          var log = [];
+          http(url: '/url', method: 'GET');
+          pendingAsync.whenStable(() {
+            log.add('whenStable');
+          });
+          log.add(1);
+          backend.flushGET('/url').respond('');
+          microLeap();
+          log.add(2);
+          expect(log).toEqual([1, 'whenStable', 2]);
+        }));
+      });
 
       it('should do basic request', async(() {
         http(url: '/url', method: 'GET');


### PR DESCRIPTION
A new PendingAsync service that is used to track pending async
operations in Angular.  VmTurnZone ties in to this service to track
timers as async tasks and correctly handles canceled timers.  Http
registers async tasks for network requests.  The Testability API uses
the new API to provide a much more useful whenStable implementation.
