### PR TITLE
fix(ng-include): do not try to update destroyed scopes.

### DIFF
--- a/lib/directive/ng_include.dart
+++ b/lib/directive/ng_include.dart
@@ -42,6 +42,7 @@ class NgInclude {
   }
 
   _updateContent(ViewFactory viewFactory) {
+    if (scope.isDestroyed) return;
     // create a new scope
     _childScope = scope.createProtoChild();
     _view = viewFactory(_childScope, directiveInjector);


### PR DESCRIPTION
Because fetching templates is asyncronous it is possible for scope be
destroyed by the time the template arrives.
