### PR TITLE
fix(introspection): fix ngProbe with introspected bindings and findEleme...

### DIFF
--- a/lib/change_detection/ast.dart
+++ b/lib/change_detection/ast.dart
@@ -19,6 +19,7 @@ abstract class AST {
   }
   WatchRecord<_Handler> setupWatch(WatchGroup watchGroup);
   String toString() => expression;
+  List<String> getBindings() => parsedExp.getBindings();
 }
 
 /**

--- a/lib/core/parser/syntax.dart
+++ b/lib/core/parser/syntax.dart
@@ -1,7 +1,7 @@
 library angular.core.parser.syntax;
 
 import 'package:angular/core/parser/parser.dart' show LocalsWrapper;
-import 'package:angular/core/parser/unparser.dart' show Unparser;
+import 'package:angular/core/parser/unparser.dart' show Unparser, BindingUnparser;
 import 'package:angular/core/parser/utils.dart' show EvalError;
 import 'package:angular/core/formatter.dart' show FormatterMap;
 
@@ -48,6 +48,7 @@ abstract class Expression {
 
   accept(Visitor visitor);
   String toString() => Unparser.unparse(this);
+  List<String> getBindings() => BindingUnparser.unparse(this);
 }
 
 class BoundExpression {

--- a/lib/core/parser/unparser.dart
+++ b/lib/core/parser/unparser.dart
@@ -2,6 +2,86 @@ library angular.core.parser.unparser;
 
 import 'package:angular/core/parser/syntax.dart';
 
+class BindingUnparser extends Visitor {
+  List<String> bindings;
+
+  BindingUnparser(this.bindings);
+
+  static List<String> unparse(Expression expression) {
+    List<String> bindings = [];
+    BindingUnparser unparser = new BindingUnparser(bindings);
+    unparser.visit(expression);
+    return bindings;
+  }
+
+  void visitChain(Chain chain) {
+    for (int i = 0; i < chain.expressions.length; i++) {
+      visit(chain.expressions[i]);
+    }
+  }
+
+  void visitFormatter(Formatter formatter) {
+    visit(formatter.expression);
+    for (int i = 0; i < formatter.arguments.length; i++) {
+      visit(formatter.arguments[i]);
+    }
+  }
+
+  void visitAssign(Assign assign) {
+    visit(assign.target);
+    visit(assign.value);
+  }
+
+  void visitConditional(Conditional conditional) {
+    visit(conditional.condition);
+    visit(conditional.yes);
+    visit(conditional.no);
+  }
+
+  void visitAccessMember(AccessMember access) {
+    visit(access.object);
+  }
+
+  void visitAccessKeyed(AccessKeyed access) {
+    visit(access.object);
+    visit(access.key);
+  }
+
+  void visitCallFunction(CallFunction call) {
+    visit(call.function);
+  }
+
+  void visitCallMember(CallMember call) {
+    visit(call.object);
+  }
+
+  void visitPrefix(Prefix prefix) {
+    visit(prefix.expression);
+  }
+
+  void visitBinary(Binary binary) {
+    visit(binary.left);
+    visit(binary.right);
+  }
+
+  void visitLiteralArray(LiteralArray literal) {
+    for (int i = 0; i < literal.elements.length; i++) {
+      visit(literal.elements[i]);
+    }
+  }
+
+  void visitLiteralObject(LiteralObject literal) {
+    List<String> keys = literal.keys;
+    for (int i = 0; i < keys.length; i++) {
+      visit(literal.values[i]);
+    }
+  }
+
+  void visitAccessScope(AccessScope access) {
+    bindings.add(access.name);
+  }
+}
+
 class Unparser extends Visitor {
   final StringBuffer buffer;
   Unparser(this.buffer);

--- a/lib/core_dom/element_binder.dart
+++ b/lib/core_dom/element_binder.dart
@@ -297,7 +297,7 @@ class ElementBinder {
         if (config != null) config(nodeInjector);
       }
       if (_config.elementProbeEnabled && ref.valueAST != null) {
-        nodeInjector.elementProbe.bindingExpressions.add(ref.valueAST.expression);
+        nodeInjector.elementProbe.bindingExpressions.addAll(ref.valueAST.getBindings());
       }
     }
 

--- a/lib/introspection.dart
+++ b/lib/introspection.dart
@@ -73,6 +73,14 @@ List<ElementProbe> _findAllProbesInTree(dom.Node node) {
 }
 
 
+dom.Element _nearestElementAncestory(dom.Node node) {
+  if (node.nodeType == dom.Node.ELEMENT_NODE) {
+    return node;
+  } else {
+    return _nearestElementAncestory(node.parentNode);
+  }
+}
+
 /**
  * Return the [ElementProbe] object for the closest [Element] in the hierarchy.
  *
@@ -276,21 +284,26 @@ class _Testability implements _JsObjectProxyable {
    * Returns a list of all nodes in the selected tree that have an `ng-model`
    * binding specified by the [modelString].  If the optional [exactMatch]
    * parameter is provided and true, it restricts the searches to bindings that
-   * are exact matches for [modelString].
+   * are exact matches for [modelString].  If the optional [allowNonElementNodes]
+   * parameter is true, returned values will be the nearest parent node which is
+   * an element.
    */
-  List<dom.Node> findModels(String modelString, [bool exactMatch]) => _findByExpression(
-      modelString, exactMatch, (ElementProbe probe) => probe.modelExpressions);
+  List<dom.Node> findModels(String modelString, [bool exactMatch, bool allowNonElementNodes]) => _findByExpression(
+      modelString, exactMatch, allowNonElementNodes, (ElementProbe probe) => probe.modelExpressions);
 
   /**
    * Returns a list of all nodes in the selected tree that have `ng-bind` or
    * mustache bindings specified by the [bindingString].  If the optional
    * [exactMatch] parameter is provided and true, it restricts the searches to
-   * bindings that are exact matches for [bindingString].
+   * bindings that are exact matches for [bindingString].  If the optional
+   * [allowNonElementNodes] parameter is true, returned values will be the nearest parent
+   * node which is an element.
    */
-  List<dom.Node> findBindings(String bindingString, [bool exactMatch]) => _findByExpression(
-      bindingString, exactMatch, (ElementProbe probe) => probe.bindingExpressions);
+  List<dom.Node> findBindings(String bindingString, [bool exactMatch, bool allowNonElementNodes]) => _findByExpression(
+      bindingString, exactMatch, allowNonElementNodes, (ElementProbe probe) => probe.bindingExpressions);
 
-  List<dom.Node> _findByExpression(String query, bool exactMatch, _GetExpressionsFromProbe getExpressions) {
+  List<dom.Node> _findByExpression(String query, bool exactMatch, bool allowNonElementNodes, _GetExpressionsFromProbe getExpressions) {
+
     List<ElementProbe> probes = _findAllProbesInTree(node);
     if (probes.length == 0) {
       probes.add(_findProbeWalkingUp(node));
@@ -298,8 +311,15 @@ class _Testability implements _JsObjectProxyable {
     List<dom.Node> results = [];
     for (ElementProbe probe in probes) {
       for (String expression in getExpressions(probe)) {
-        if(exactMatch == true ? expression == query : expression.indexOf(query) >= 0) {
-          results.add(probe.element);
+        if (exactMatch == true ? expression == query : expression.indexOf(query) >= 0) {
+          if (allowNonElementNodes == true) {
+            results.add(probe.element);
+          } else {
+            var nearestElement = _nearestElementAncestory(probe.element);
+            if (!results.contains(nearestElement)) {
+              results.add(nearestElement);
+            }
+          }
         }
       }
     }
@@ -316,10 +336,10 @@ class _Testability implements _JsObjectProxyable {
   js.JsObject _toJsObject() {
     return _jsify({
         'allowAnimations': allowAnimations,
-        'findBindings': (bindingString, [exactMatch]) =>
-            findBindings(bindingString, exactMatch),
-        'findModels': (modelExpressions, [exactMatch]) =>
-            findModels(modelExpressions, exactMatch),
+        'findBindings': (bindingString, [exactMatch, allowNonElementNodes]) =>
+            findBindings(bindingString, exactMatch, allowNonElementNodes),
+        'findModels': (modelExpressions, [exactMatch, allowNonElementNodes]) =>
+            findModels(modelExpressions, exactMatch, allowNonElementNodes),
         'whenStable': (callback) =>
             whenStable(() => callback.apply([])),
         'notifyWhenNoOutstandingRequests': (callback) {

--- a/test/introspection_spec.dart
+++ b/test/introspection_spec.dart
@@ -7,50 +7,76 @@ import 'dart:html';
 
 void main() {
   describe('introspection', () {
-    it('should retrieve ElementProbe', (TestBed _) {
-      _.compile('<div ng-bind="true"></div>');
-      ElementProbe probe = ngProbe(_.rootElement);
-      expect(probe.injector.get(Injector)).toBe(_.injector);
-      expect(ngInjector(_.rootElement).get(Injector)).toBe(_.injector);
-      expect(probe.directives[0] is NgBind).toBe(true);
-      expect(ngDirectives(_.rootElement)[0] is NgBind).toBe(true);
-      expect(probe.scope).toBe(_.rootScope);
-      expect(ngScope(_.rootElement)).toBe(_.rootScope);
+    describe('ngQuery', () {
+      toHtml(List list) => list.map((e) => e.outerHtml).join('');
+
+      it('should select elements using CSS selector', () {
+        var div = new Element.html('<div><p><span></span></p></div>');
+        var span = div.querySelector('span');
+        var shadowRoot = span.createShadowRoot();
+        shadowRoot.innerHtml = '<ul><li>stash</li><li>secret</li><ul>';
+
+        expect(toHtml(ngQuery(div, 'li'))).toEqual('<li>stash</li><li>secret</li>');
+        expect(toHtml(ngQuery(div, 'li', 'stash'))).toEqual('<li>stash</li>');
+        expect(toHtml(ngQuery(div, 'li', 'secret'))).toEqual('<li>secret</li>');
+        expect(toHtml(ngQuery(div, 'li', 'xxx'))).toEqual('');
+      });
+
+      it('should select elements in the root shadow root', () {
+        var div = new Element.html('<div></div>');
+        var shadowRoot = div.createShadowRoot();
+        shadowRoot.innerHtml = '<ul><li>stash</li><li>secret</li><ul>';
+        expect(toHtml(ngQuery(div, 'li'))).toEqual('<li>stash</li><li>secret</li>');
+      });
     });
 
-    toHtml(List list) => list.map((e) => e.outerHtml).join('');
+    describe('ngProbe', () {
+      it('should retrieve ElementProbe', (TestBed _) {
+        _.compile('<div ng-bind="foo"></div>');
 
-    it('should select elements using CSS selector', () {
-      var div = new Element.html('<div><p><span></span></p></div>');
-      var span = div.querySelector('span');
-      var shadowRoot = span.createShadowRoot();
-      shadowRoot.innerHtml = '<ul><li>stash</li><li>secret</li><ul>';
+        ElementProbe probe = ngProbe(_.rootElement);
 
-      expect(toHtml(ngQuery(div, 'li'))).toEqual('<li>stash</li><li>secret</li>');
-      expect(toHtml(ngQuery(div, 'li', 'stash'))).toEqual('<li>stash</li>');
-      expect(toHtml(ngQuery(div, 'li', 'secret'))).toEqual('<li>secret</li>');
-      expect(toHtml(ngQuery(div, 'li', 'xxx'))).toEqual('');
-    });
+        expect(probe.injector.get(Injector)).toBe(_.injector);
+        expect(ngInjector(_.rootElement).get(Injector)).toBe(_.injector);
+        expect(probe.directives[0] is NgBind).toBe(true);
+        expect(ngDirectives(_.rootElement)[0] is NgBind).toBe(true);
+        expect(probe.scope).toBe(_.rootScope);
+        expect(ngScope(_.rootElement)).toBe(_.rootScope);
+        expect(probe.bindingExpressions).toEqual(['foo']);
+      });
 
-    it('should select probe using CSS selector', (TestBed _) {
-      _.compile('<div ng-show="true">WORKS</div>');
-      document.body.append(_.rootElement);
-      var div = new Element.html('<div><p><span></span></p></div>');
-      var span = div.querySelector('span');
-      var shadowRoot = span.createShadowRoot();
-      shadowRoot.innerHtml = '<ul><li>stash</li><li>secret</li><ul>';
+      it('should select probe using CSS selector', (TestBed _) {
+        _.compile('<div ng-show="true">WORKS</div>');
+        document.body.append(_.rootElement);
 
-      ElementProbe probe = ngProbe('[ng-show]');
-      expect(probe).toBeDefined();
-      expect(probe.injector.get(NgShow) is NgShow).toEqual(true);
-      _.rootElement.remove();
-    });
+        ElementProbe probe = ngProbe('[ng-show]');
 
-    it('should select elements in the root shadow root', () {
-      var div = new Element.html('<div></div>');
-      var shadowRoot = div.createShadowRoot();
-      shadowRoot.innerHtml = '<ul><li>stash</li><li>secret</li><ul>';
-      expect(toHtml(ngQuery(div, 'li'))).toEqual('<li>stash</li><li>secret</li>');
+        expect(probe).toBeDefined();
+        expect(probe.injector.get(NgShow) is NgShow).toEqual(true);
+        _.rootElement.remove();
+      });
+
+      it('should return the correct binding expression for mustache interpolation', (TestBed _) {
+        _.compile('<div my-attr="{{foobar}}"></div>');
+
+        ElementProbe probe = ngProbe(_.rootElement);
+
+        expect(probe.injector.get(Injector)).toBe(_.injector);
+
+        expect(ngInjector(_.rootElement).get(Injector)).toBe(_.injector);
+        expect(probe.bindingExpressions).toEqual(['foobar']);
+      });
+
+      it('should return the correct binding expressions for repeated bindings', (TestBed _) {
+        _.compile('<div my-attr="{{foo}} then {{bar}}"></div>');
+
+        ElementProbe probe = ngProbe(_.rootElement);
+
+        expect(probe.injector.get(Injector)).toBe(_.injector);
+
+        expect(ngInjector(_.rootElement).get(Injector)).toBe(_.injector);
+        expect(probe.bindingExpressions).toEqual(['foo', 'bar']);
+      });
     });
 
     describe('getTestability', () {
@@ -89,15 +115,18 @@ void main() {
       }
     });
 
-    describe('JavaScript bindings', () {
-      var elt, angular, ngtop;
+    describe('JavaScript testability', () {
+      var elt, angular, ngtop, testability;
 
       beforeEach(() {
-        elt = e('<div ng-app id="ngtop" ng-model="myModel">'
-                    '<div ng-bind="\'introspection FTW\'"></div>'
-                    '<div my-attr="{{attrMustache}}"></div>'
-                    '<div>{{textMustache}}</div>'
-                '</div>');
+        elt = e('''<div ng-app id="ngtop">
+                     <div id="a" ng-bind="\'introspection FTW\'"></div>
+                     <div id="b" my-attr="{{attrMustache}}"></div>
+                     <div id="c">{{textMustache}}</div>
+                     <div id="d">hi {{repeat}} this is {{repeat}}</div>
+                     <div id="e">{{first}} then {{second}}</div>
+                     <input id="1" ng-model="myModel"/>
+                  </div>''');
         // Make it possible to find the element from JS
         document.body.append(elt);
         (applicationFactory()..element = elt).run();
@@ -105,6 +134,7 @@ void main() {
         // Polymer does not support accessing named elements directly (e.g. window.ngtop)
         // so we need to use getElementById to support Polymer's shadow DOM polyfill.
         ngtop = document.getElementById('ngtop');
+        testability = angular['getTestability'].apply([ngtop]);
       });
 
       afterEach(() {
@@ -122,79 +152,94 @@ void main() {
         expect(angular['resumeBootstrap']).toBeDefined();
         expect(angular['getTestability']).toBeDefined();
 
-        expect(js.context['ngProbe'].apply([ngtop])).toBeDefined();
+        expect(js.context['ngProbe'].apply([document.getElementById('a')])).toBeDefined();
+
+        expect(testability).toBeDefined();
       });
 
-      describe(r'testability', () {
+      it('should expose allowAnimations', () {
+        allowAnimations(allowed) => testability['allowAnimations'].apply([allowed]);
+        expect(allowAnimations(false)).toEqual(true);
+        expect(allowAnimations(false)).toEqual(false);
+        expect(allowAnimations(true)).toEqual(false);
+        expect(allowAnimations(true)).toEqual(true);
+      });
 
-        var testability;
-
-        beforeEach(() {
-          testability = angular['getTestability'].apply([ngtop]);
-        });
-
-        it('should be available from Javascript', () {
-          expect(testability).toBeDefined();
-        });
-
-        it('should expose allowAnimations', () {
-          allowAnimations(allowed) => testability['allowAnimations'].apply([allowed]);
-          expect(allowAnimations(false)).toEqual(true);
-          expect(allowAnimations(false)).toEqual(false);
-          expect(allowAnimations(true)).toEqual(false);
-          expect(allowAnimations(true)).toEqual(true);
-        });
-
-        describe('bindings', () {
-          it('should find exact bindings', () {
-            // exactMatch should fail.
-            var bindingNodes = testability['findBindings'].apply(['introspection', true]);
-            expect(bindingNodes.length).toEqual(0);
-
-            // substring search (default) should succeed.
-            // exactMatch should default to false.
-            bindingNodes = testability['findBindings'].apply(['introspection']);
-            expect(bindingNodes.length).toEqual(1);
-            bindingNodes = testability['findBindings'].apply(['introspection', false]);
-            expect(bindingNodes.length).toEqual(1);
-
-            // and so should exact search with the correct query.
-            bindingNodes = testability['findBindings'].apply(["'introspection FTW'", true]);
-            expect(bindingNodes.length).toEqual(1);
-          });
-
-          _assertBinding(String query) {
-            var bindingNodes = testability['findBindings'].apply([query]);
-            expect(bindingNodes.length).toEqual(1);
-            var node = bindingNodes[0];
-            var probe = js.context['ngProbe'].apply([node]);
-            expect(probe).toBeDefined();
-            var bindings = probe['bindings'];
-            expect(bindings['length']).toEqual(1);
-            expect(bindings[0].contains(query)).toBe(true);
-          }
-
-          it('should find ng-bind bindings', () => _assertBinding('introspection FTW'));
-          it('should find attribute mustache bindings', () => _assertBinding('attrMustache'));
-          it('should find text mustache bindings', () => _assertBinding('textMustache'));
-        });
-
-        it('should find models', () {
+      describe('bindings', () {
+        it('should find bindings', () {
           // exactMatch should fail.
-          var modelNodes = testability['findModels'].apply(['my', true]);
-          expect(modelNodes.length).toEqual(0);
+          var bindingNodes = testability['findBindings'].apply(['introspection', true]);
+          expect(bindingNodes.length).toEqual(0);
 
           // substring search (default) should succeed.
-          modelNodes = testability['findModels'].apply(['my']);
-          expect(modelNodes.length).toEqual(1);
-          var divElement = modelNodes[0];
-          expect(divElement is DivElement).toEqual(true);
-          var probe = js.context['ngProbe'].apply([divElement]);
-          expect(probe).toBeDefined();
-          var models = probe['models'];
-          expect(models['length']).toEqual(1);
-          expect(models[0]).toEqual('myModel');
+          // exactMatch should default to false.
+          bindingNodes = testability['findBindings'].apply(['introspection']);
+          expect(bindingNodes.length).toEqual(1);
+          bindingNodes = testability['findBindings'].apply(['introspection', false]);
+          expect(bindingNodes.length).toEqual(1);
+
+          // and so should exact search with the correct query.
+          bindingNodes = testability['findBindings'].apply(["'introspection FTW'", true]);
+          expect(bindingNodes.length).toEqual(1);
         });
+
+        it('should find ng-bind bindings', () {
+          var bindingElems = testability['findBindings'].apply(['introspection FTW']);
+          expect(bindingElems.length).toEqual(1);
+          expect(bindingElems[0]).toEqual(document.getElementById('a'));
+        });
+
+        it('should find attribute mustache bindings', () {
+          var bindingElems = testability['findBindings'].apply(['attrMustache']);
+          expect(bindingElems.length).toEqual(1);
+          expect(bindingElems[0]).toEqual(document.getElementById('b'));
+        });
+
+        it('should find text mustache bindings', () {
+          var bindingElems = testability['findBindings'].apply(['textMustache']);
+          expect(bindingElems.length).toEqual(1);
+          expect(bindingElems[0]).toEqual(document.getElementById('c'));
+        });
+
+        it('should find exact mustache bindings', () {
+          var bindingAttrElems = testability['findBindings'].apply(['attrMustache', true]);
+          expect(bindingAttrElems.length).toEqual(1);
+
+          var bindingTextElems = testability['findBindings'].apply(['textMustache', true]);
+          expect(bindingTextElems.length).toEqual(1);
+        });
+
+        it('should find repeated bindings and return only one element', () {
+          var bindingElems = testability['findBindings'].apply(['repeat']);
+          expect(bindingElems.length).toEqual(1);
+          expect(bindingElems[0]).toEqual(document.getElementById('d'));
+        });
+
+        it('should find elements with more than one binding by either', () {
+          var firstBindingElems = testability['findBindings'].apply(['first']);
+          var secondBindingElems = testability['findBindings'].apply(['second']);
+          expect(firstBindingElems.length).toEqual(1);
+          expect(secondBindingElems.length).toEqual(1);
+          expect(firstBindingElems[0]).toEqual(secondBindingElems[0]);
+
+        });
+
+        it('should return nodes instead of elements if requested', () {
+          var bindingNodes = testability['findBindings'].apply(['textMustache', false, true]);
+          expect(bindingNodes.length).toEqual(1);
+          expect(bindingNodes[0]).toEqual(document.getElementById('c').firstChild);
+        });
+      });
+
+      it('should find models', () {
+        // exactMatch should fail.
+        var modelNodes = testability['findModels'].apply(['my', true]);
+        expect(modelNodes.length).toEqual(0);
+
+        // substring search (default) should succeed.
+        modelNodes = testability['findModels'].apply(['my']);
+        expect(modelNodes.length).toEqual(1);
+        expect(modelNodes[0]).toEqual(document.getElementById('1'));
       });
     });
   });


### PR DESCRIPTION
...nts returning only elements

This change
1) organizes the introspection unit tests to more clearly separate them into
elementProbe tests and testability tests.

2) Adds a `getBindings` method to AST and Expression, which uses the BindingUnparser
to return a list of binding strings.

3) Adds an optional third parameter to findElements and findBindings which makes
the returned list include only elements or both elements and nodes (in practice,
these are text nodes). This defaults to only returning elements.
