### PR TITLE
fix(introspection): fix ngProbe with introspected bindings and findEleme...

### DIFF
--- a/lib/core/interpolate.dart
+++ b/lib/core/interpolate.dart
@@ -1,5 +1,14 @@
 part of angular.core_internal;
 
+class Interpolation {
+  final String expression;
+  final List<String> bindingExpressions;
+
+  Interpolation(this.expression, this.bindingExpressions);
+}
+
+final EMPTY_INTERPOLATION = new Interpolation("", <String>[]);
+
 /**
  * Compiles a string with markup into an expression. This service is used by the
  * HTML [Compiler] service for data binding.
@@ -15,6 +24,7 @@ class Interpolate implements Function {
   Interpolate(CacheRegister cacheRegister) {
     cacheRegister.registerCache("Interpolate", _cache);
   }
+
   /**
    * Compiles markup text into expression.
    *
@@ -25,9 +35,8 @@ class Interpolate implements Function {
    * - [startSymbol]: The symbol to start interpolation. '{{' by default.
    * - [endSymbol]: The symbol to end interpolation. '}}' by default.
    */
-
-  String call(String template, [bool mustHaveExpression = false,
-              String startSymbol = '{{', String endSymbol = '}}']) {
+  Interpolation call(String template, [bool mustHaveExpression = false,
+                            String startSymbol = '{{', String endSymbol = '}}']) {
     if (mustHaveExpression == false && startSymbol == '{{' && endSymbol == '}}') {
       // cachable
       return _cache.putIfAbsent(template, () => _call(template, mustHaveExpression, startSymbol, endSymbol));
@@ -35,9 +44,9 @@ class Interpolate implements Function {
     return _call(template, mustHaveExpression, startSymbol, endSymbol);
   }
 
-  String _call(String template, [bool mustHaveExpression = false,
-              String startSymbol, String endSymbol]) {
-    if (template == null || template.isEmpty) return "";
+  Interpolation _call(String template, [bool mustHaveExpression = false,
+                      String startSymbol, String endSymbol]) {
+    if (template == null || template.isEmpty) return EMPTY_INTERPOLATION;
 
     final startLen = startSymbol.length;
     final endLen = endSymbol.length;
@@ -51,6 +60,7 @@ class Interpolate implements Function {
 
     String exp;
     final expParts = <String>[];
+    final bindings = <String>[];
 
     while (index < length) {
       startIdx = template.indexOf(startSymbol, index);
@@ -61,7 +71,9 @@ class Interpolate implements Function {
           // formatter
           expParts.add(_wrapInQuotes(template.substring(index, startIdx)));
         }
-        expParts.add('(' + template.substring(startIdx + startLen, endIdx) + '|stringify)');
+        var binding = template.substring(startIdx + startLen, endIdx);
+        bindings.add(binding);
+        expParts.add('(' + binding + '|stringify)');
 
         index = endIdx + endLen;
         hasInterpolation = true;
@@ -72,7 +84,8 @@ class Interpolate implements Function {
       }
     }
 
-    return !mustHaveExpression || hasInterpolation ? expParts.join('+') : null;
+    return !mustHaveExpression || hasInterpolation ?
+        new Interpolation(expParts.join('+'), bindings) : null;
   }
 
   String _wrapInQuotes(String s){

--- a/lib/core_dom/common.dart
+++ b/lib/core_dom/common.dart
@@ -29,8 +29,9 @@ class DirectiveRef {
   final String value;
   final AST valueAST;
   final mappings = <MappingParts>[];
+  final List<String> bindingExpressions;
 
-  DirectiveRef(this.element, type, this.annotation, this.typeKey, [ this.value, this.valueAST ])
+  DirectiveRef(this.element, type, this.annotation, this.typeKey, [ this.value, this.valueAST, this.bindingExpressions ])
       : type = type,
         factory = Module.DEFAULT_REFLECTOR.factoryFor(type),
         paramKeys = Module.DEFAULT_REFLECTOR.parameterKeysFor(type);

--- a/lib/core_dom/element_binder.dart
+++ b/lib/core_dom/element_binder.dart
@@ -296,8 +296,8 @@ class ElementBinder {
         DirectiveBinderFn config = ref.annotation.module;
         if (config != null) config(nodeInjector);
       }
-      if (_config.elementProbeEnabled && ref.valueAST != null) {
-        nodeInjector.elementProbe.bindingExpressions.add(ref.valueAST.expression);
+      if (_config.elementProbeEnabled && ref.bindingExpressions != null) {
+        nodeInjector.elementProbe.bindingExpressions.addAll(ref.bindingExpressions);
       }
     }
 

--- a/lib/core_dom/selector.dart
+++ b/lib/core_dom/selector.dart
@@ -105,10 +105,10 @@ class DirectiveSelector {
           // the value. Yes it is a bit of a hack.
           _directives[selectorRegExp.selector].forEach((DirectiveTypeTuple tuple) {
             // Pre-compute the AST to watch this value.
-            String expression = _interpolate(value);
-            AST valueAST = _astParser(expression, formatters: _formatters);
+            Interpolation interpolation = _interpolate(value);
+            AST valueAST = _astParser(interpolation.expression, formatters: _formatters);
             builder.addDirective(new DirectiveRef(
-                node, tuple.type, tuple.directive, new Key(tuple.type), attrName, valueAST));
+                node, tuple.type, tuple.directive, new Key(tuple.type), attrName, valueAST, interpolation.bindingExpressions));
           });
         }
       }
@@ -143,11 +143,11 @@ class DirectiveSelector {
       if (selectorRegExp.regexp.hasMatch(value)) {
         _directives[selectorRegExp.selector].forEach((tuple) {
           // Pre-compute the AST to watch this value.
-          String expression = _interpolate(value);
-          var valueAST = _astParser(expression, formatters: _formatters);
+          Interpolation interpolation = _interpolate(value);
+          var valueAST = _astParser(interpolation.expression, formatters: _formatters);
 
           builder.addDirective(new DirectiveRef(node, tuple.type,
-              tuple.directive, new Key(tuple.type), value, valueAST));
+              tuple.directive, new Key(tuple.type), value, valueAST, interpolation.bindingExpressions));
         });
       }
     }

--- a/lib/directive/ng_pluralize.dart
+++ b/lib/directive/ng_pluralize.dart
@@ -168,7 +168,7 @@ class NgPluralize {
   void _setAndWatch(template) {
     if (_watch != null) _watch.remove();
     var expression = _expressionCache.putIfAbsent(template, () =>
-        _interpolate(template, false, r'${', '}'));
+        _interpolate(template, false, r'${', '}').expression);
     _watch = _scope.watch(expression, _updateMarkup, formatters: _formatters);
   }
 

--- a/test/core/interpolate_spec.dart
+++ b/test/core/interpolate_spec.dart
@@ -15,27 +15,34 @@ main() {
     });
 
     it('should return an expression', (Interpolate interpolate) {
-      expect(interpolate('Hello {{name}}!'))
+      expect(interpolate('Hello {{name}}!').expression)
           .toEqual('"Hello "+(name|stringify)+"!"');
-      expect(interpolate('a{{b}}C'))
+      expect(interpolate('a{{b}}C').expression)
           .toEqual('"a"+(b|stringify)+"C"');
-      expect(interpolate('a{{b}}')).toEqual('"a"+(b|stringify)');
-      expect(interpolate('{{a}}b')).toEqual('(a|stringify)+"b"');
-      expect(interpolate('{{b}}')).toEqual('(b|stringify)');
-      expect(interpolate('{{b}}+{{c}}'))
+      expect(interpolate('a{{b}}').expression).toEqual('"a"+(b|stringify)');
+      expect(interpolate('{{a}}b').expression).toEqual('(a|stringify)+"b"');
+      expect(interpolate('{{b}}').expression).toEqual('(b|stringify)');
+      expect(interpolate('{{b}}+{{c}}').expression)
           .toEqual('(b|stringify)+"+"+(c|stringify)');
-      expect(interpolate('{{b}}x{{c}}'))
+      expect(interpolate('{{b}}x{{c}}').expression)
           .toEqual('(b|stringify)+"x"+(c|stringify)');
     });
 
+    it('should return expression bindings', (Interpolate interpolate) {
+      expect(interpolate('Hello {{name}}').bindingExpressions).toEqual(['name']);
+      expect(interpolate('a{{b}}C').bindingExpressions)
+          .toEqual(['b']);
+      expect(interpolate('{{b}}x{{c}}').bindingExpressions).toEqual(['b', 'c']);
+    });
+
     it('should Parse Multiline', (Interpolate interpolate) {
-      expect(interpolate("X\nY{{A\n+B}}C\nD"))
+      expect(interpolate("X\nY{{A\n+B}}C\nD").expression)
       .toEqual('"X\nY"+(A\n+B|stringify)+"C\nD"');
     });
 
     it('should escape double quotes', (Interpolate interpolate) {
-      expect(interpolate(r'"{{a}}')).toEqual(r'"\""+(a|stringify)');
-      expect(interpolate(r'\"{{a}}')).toEqual(r'"\\\""+(a|stringify)');
+      expect(interpolate(r'"{{a}}').expression).toEqual(r'"\""+(a|stringify)');
+      expect(interpolate(r'\"{{a}}').expression).toEqual(r'"\\\""+(a|stringify)');
     });
   });
 }

--- a/test/introspection_spec.dart
+++ b/test/introspection_spec.dart
@@ -7,50 +7,76 @@ import 'dart:html';
 
 void main() {
   describe('introspection', () {
-    it('should retrieve ElementProbe', (TestBed _) {
-      _.compile('<div ng-bind="true"></div>');
-      ElementProbe probe = ngProbe(_.rootElement);
-      expect(probe.injector.get(Injector)).toBe(_.injector);
-      expect(ngInjector(_.rootElement).get(Injector)).toBe(_.injector);
-      expect(probe.directives[0] is NgBind).toBe(true);
-      expect(ngDirectives(_.rootElement)[0] is NgBind).toBe(true);
-      expect(probe.scope).toBe(_.rootScope);
-      expect(ngScope(_.rootElement)).toBe(_.rootScope);
+    describe('ngQuery', () {
+      toHtml(List list) => list.map((e) => e.outerHtml).join('');
+
+      it('should select elements using CSS selector', () {
+        var div = new Element.html('<div><p><span></span></p></div>');
+        var span = div.querySelector('span');
+        var shadowRoot = span.createShadowRoot();
+        shadowRoot.innerHtml = '<ul><li>stash</li><li>secret</li><ul>';
+
+        expect(toHtml(ngQuery(div, 'li'))).toEqual('<li>stash</li><li>secret</li>');
+        expect(toHtml(ngQuery(div, 'li', 'stash'))).toEqual('<li>stash</li>');
+        expect(toHtml(ngQuery(div, 'li', 'secret'))).toEqual('<li>secret</li>');
+        expect(toHtml(ngQuery(div, 'li', 'xxx'))).toEqual('');
+      });
+
+      it('should select elements in the root shadow root', () {
+        var div = new Element.html('<div></div>');
+        var shadowRoot = div.createShadowRoot();
+        shadowRoot.innerHtml = '<ul><li>stash</li><li>secret</li><ul>';
+        expect(toHtml(ngQuery(div, 'li'))).toEqual('<li>stash</li><li>secret</li>');
+      });
     });
 
-    toHtml(List list) => list.map((e) => e.outerHtml).join('');
+    describe('ngProbe', () {
+      it('should retrieve ElementProbe', (TestBed _) {
+        _.compile('<div ng-bind="foo"></div>');
 
-    it('should select elements using CSS selector', () {
-      var div = new Element.html('<div><p><span></span></p></div>');
-      var span = div.querySelector('span');
-      var shadowRoot = span.createShadowRoot();
-      shadowRoot.innerHtml = '<ul><li>stash</li><li>secret</li><ul>';
+        ElementProbe probe = ngProbe(_.rootElement);
 
-      expect(toHtml(ngQuery(div, 'li'))).toEqual('<li>stash</li><li>secret</li>');
-      expect(toHtml(ngQuery(div, 'li', 'stash'))).toEqual('<li>stash</li>');
-      expect(toHtml(ngQuery(div, 'li', 'secret'))).toEqual('<li>secret</li>');
-      expect(toHtml(ngQuery(div, 'li', 'xxx'))).toEqual('');
-    });
+        expect(probe.injector.get(Injector)).toBe(_.injector);
+        expect(ngInjector(_.rootElement).get(Injector)).toBe(_.injector);
+        expect(probe.directives[0] is NgBind).toBe(true);
+        expect(ngDirectives(_.rootElement)[0] is NgBind).toBe(true);
+        expect(probe.scope).toBe(_.rootScope);
+        expect(ngScope(_.rootElement)).toBe(_.rootScope);
+        expect(probe.bindingExpressions).toEqual(['foo']);
+      });
 
-    it('should select probe using CSS selector', (TestBed _) {
-      _.compile('<div ng-show="true">WORKS</div>');
-      document.body.append(_.rootElement);
-      var div = new Element.html('<div><p><span></span></p></div>');
-      var span = div.querySelector('span');
-      var shadowRoot = span.createShadowRoot();
-      shadowRoot.innerHtml = '<ul><li>stash</li><li>secret</li><ul>';
+      it('should select probe using CSS selector', (TestBed _) {
+        _.compile('<div ng-show="true">WORKS</div>');
+        document.body.append(_.rootElement);
 
-      ElementProbe probe = ngProbe('[ng-show]');
-      expect(probe).toBeDefined();
-      expect(probe.injector.get(NgShow) is NgShow).toEqual(true);
-      _.rootElement.remove();
-    });
+        ElementProbe probe = ngProbe('[ng-show]');
 
-    it('should select elements in the root shadow root', () {
-      var div = new Element.html('<div></div>');
-      var shadowRoot = div.createShadowRoot();
-      shadowRoot.innerHtml = '<ul><li>stash</li><li>secret</li><ul>';
-      expect(toHtml(ngQuery(div, 'li'))).toEqual('<li>stash</li><li>secret</li>');
+        expect(probe).toBeDefined();
+        expect(probe.injector.get(NgShow) is NgShow).toEqual(true);
+        _.rootElement.remove();
+      });
+
+      it('should return the correct binding expression for mustache interpolation', (TestBed _) {
+        _.compile('<div my-attr="{{foobar}}"></div>');
+
+        ElementProbe probe = ngProbe(_.rootElement);
+
+        expect(probe.injector.get(Injector)).toBe(_.injector);
+
+        expect(ngInjector(_.rootElement).get(Injector)).toBe(_.injector);
+        expect(probe.bindingExpressions).toEqual(['foobar']);
+      });
+
+      it('should return the correct binding expressions for repeated bindings', (TestBed _) {
+        _.compile('<div my-attr="{{foo}} then {{bar}}"></div>');
+
+        ElementProbe probe = ngProbe(_.rootElement);
+
+        expect(probe.injector.get(Injector)).toBe(_.injector);
+
+        expect(ngInjector(_.rootElement).get(Injector)).toBe(_.injector);
+        expect(probe.bindingExpressions).toEqual(['foo', 'bar']);
+      });
     });
 
     describe('getTestability', () {
@@ -89,15 +115,18 @@ void main() {
       }
     });
 
-    describe('JavaScript bindings', () {
-      var elt, angular, ngtop;
+    describe('JavaScript testability', () {
+      var elt, angular, ngtop, testability;
 
       beforeEach(() {
-        elt = e('<div ng-app id="ngtop" ng-model="myModel">'
-                    '<div ng-bind="\'introspection FTW\'"></div>'
-                    '<div my-attr="{{attrMustache}}"></div>'
-                    '<div>{{textMustache}}</div>'
-                '</div>');
+        elt = e('''<div ng-app id="ngtop">
+                     <div id="a" ng-bind="\'introspection FTW\'"></div>
+                     <div id="b" my-attr="{{attrMustache}}"></div>
+                     <div id="c">{{textMustache}}</div>
+                     <div id="d">hi {{repeat}} this is {{repeat}}</div>
+                     <div id="e">{{first}} then {{second}}</div>
+                     <input id="1" ng-model="myModel"/>
+                  </div>''');
         // Make it possible to find the element from JS
         document.body.append(elt);
         (applicationFactory()..element = elt).run();
@@ -105,6 +134,7 @@ void main() {
         // Polymer does not support accessing named elements directly (e.g. window.ngtop)
         // so we need to use getElementById to support Polymer's shadow DOM polyfill.
         ngtop = document.getElementById('ngtop');
+        testability = angular['getTestability'].apply([ngtop]);
       });
 
       afterEach(() {
@@ -122,79 +152,94 @@ void main() {
         expect(angular['resumeBootstrap']).toBeDefined();
         expect(angular['getTestability']).toBeDefined();
 
-        expect(js.context['ngProbe'].apply([ngtop])).toBeDefined();
+        expect(js.context['ngProbe'].apply([document.getElementById('a')])).toBeDefined();
+
+        expect(testability).toBeDefined();
       });
 
-      describe(r'testability', () {
+      it('should expose allowAnimations', () {
+        allowAnimations(allowed) => testability['allowAnimations'].apply([allowed]);
+        expect(allowAnimations(false)).toEqual(true);
+        expect(allowAnimations(false)).toEqual(false);
+        expect(allowAnimations(true)).toEqual(false);
+        expect(allowAnimations(true)).toEqual(true);
+      });
 
-        var testability;
-
-        beforeEach(() {
-          testability = angular['getTestability'].apply([ngtop]);
-        });
-
-        it('should be available from Javascript', () {
-          expect(testability).toBeDefined();
-        });
-
-        it('should expose allowAnimations', () {
-          allowAnimations(allowed) => testability['allowAnimations'].apply([allowed]);
-          expect(allowAnimations(false)).toEqual(true);
-          expect(allowAnimations(false)).toEqual(false);
-          expect(allowAnimations(true)).toEqual(false);
-          expect(allowAnimations(true)).toEqual(true);
-        });
-
-        describe('bindings', () {
-          it('should find exact bindings', () {
-            // exactMatch should fail.
-            var bindingNodes = testability['findBindings'].apply(['introspection', true]);
-            expect(bindingNodes.length).toEqual(0);
-
-            // substring search (default) should succeed.
-            // exactMatch should default to false.
-            bindingNodes = testability['findBindings'].apply(['introspection']);
-            expect(bindingNodes.length).toEqual(1);
-            bindingNodes = testability['findBindings'].apply(['introspection', false]);
-            expect(bindingNodes.length).toEqual(1);
-
-            // and so should exact search with the correct query.
-            bindingNodes = testability['findBindings'].apply(["'introspection FTW'", true]);
-            expect(bindingNodes.length).toEqual(1);
-          });
-
-          _assertBinding(String query) {
-            var bindingNodes = testability['findBindings'].apply([query]);
-            expect(bindingNodes.length).toEqual(1);
-            var node = bindingNodes[0];
-            var probe = js.context['ngProbe'].apply([node]);
-            expect(probe).toBeDefined();
-            var bindings = probe['bindings'];
-            expect(bindings['length']).toEqual(1);
-            expect(bindings[0].contains(query)).toBe(true);
-          }
-
-          it('should find ng-bind bindings', () => _assertBinding('introspection FTW'));
-          it('should find attribute mustache bindings', () => _assertBinding('attrMustache'));
-          it('should find text mustache bindings', () => _assertBinding('textMustache'));
-        });
-
-        it('should find models', () {
+      describe('bindings', () {
+        it('should find bindings', () {
           // exactMatch should fail.
-          var modelNodes = testability['findModels'].apply(['my', true]);
-          expect(modelNodes.length).toEqual(0);
+          var bindingNodes = testability['findBindings'].apply(['introspection', true]);
+          expect(bindingNodes.length).toEqual(0);
 
           // substring search (default) should succeed.
-          modelNodes = testability['findModels'].apply(['my']);
-          expect(modelNodes.length).toEqual(1);
-          var divElement = modelNodes[0];
-          expect(divElement is DivElement).toEqual(true);
-          var probe = js.context['ngProbe'].apply([divElement]);
-          expect(probe).toBeDefined();
-          var models = probe['models'];
-          expect(models['length']).toEqual(1);
-          expect(models[0]).toEqual('myModel');
+          // exactMatch should default to false.
+          bindingNodes = testability['findBindings'].apply(['introspection']);
+          expect(bindingNodes.length).toEqual(1);
+          bindingNodes = testability['findBindings'].apply(['introspection', false]);
+          expect(bindingNodes.length).toEqual(1);
+
+          // and so should exact search with the correct query.
+          bindingNodes = testability['findBindings'].apply(["'introspection FTW'", true]);
+          expect(bindingNodes.length).toEqual(1);
         });
+
+        it('should find ng-bind bindings', () {
+          var bindingElems = testability['findBindings'].apply(['introspection FTW']);
+          expect(bindingElems.length).toEqual(1);
+          expect(bindingElems[0]).toEqual(document.getElementById('a'));
+        });
+
+        it('should find attribute mustache bindings', () {
+          var bindingElems = testability['findBindings'].apply(['attrMustache']);
+          expect(bindingElems.length).toEqual(1);
+          expect(bindingElems[0]).toEqual(document.getElementById('b'));
+        });
+
+        it('should find text mustache bindings', () {
+          var bindingElems = testability['findBindings'].apply(['textMustache']);
+          expect(bindingElems.length).toEqual(1);
+          expect(bindingElems[0]).toEqual(document.getElementById('c'));
+        });
+
+        it('should find exact mustache bindings', () {
+          var bindingAttrElems = testability['findBindings'].apply(['attrMustache', true]);
+          expect(bindingAttrElems.length).toEqual(1);
+
+          var bindingTextElems = testability['findBindings'].apply(['textMustache', true]);
+          expect(bindingTextElems.length).toEqual(1);
+        });
+
+        it('should find repeated bindings and return only one element', () {
+          var bindingElems = testability['findBindings'].apply(['repeat']);
+          expect(bindingElems.length).toEqual(1);
+          expect(bindingElems[0]).toEqual(document.getElementById('d'));
+        });
+
+        it('should find elements with more than one binding by either', () {
+          var firstBindingElems = testability['findBindings'].apply(['first']);
+          var secondBindingElems = testability['findBindings'].apply(['second']);
+          expect(firstBindingElems.length).toEqual(1);
+          expect(secondBindingElems.length).toEqual(1);
+          expect(firstBindingElems[0]).toEqual(secondBindingElems[0]);
+
+        });
+
+        it('should return nodes instead of elements if requested', () {
+          var bindingNodes = testability['findBindings'].apply(['textMustache', false, true]);
+          expect(bindingNodes.length).toEqual(1);
+          expect(bindingNodes[0]).toEqual(document.getElementById('c').firstChild);
+        });
+      });
+
+      it('should find models', () {
+        // exactMatch should fail.
+        var modelNodes = testability['findModels'].apply(['my', true]);
+        expect(modelNodes.length).toEqual(0);
+
+        // substring search (default) should succeed.
+        modelNodes = testability['findModels'].apply(['my']);
+        expect(modelNodes.length).toEqual(1);
+        expect(modelNodes[0]).toEqual(document.getElementById('1'));
       });
     });
   });


### PR DESCRIPTION
...nts returning only elements

This change
1) organizes the introspection unit tests to more clearly separate them into
elementProbe tests and testability tests.

2) Modifies `interpolate` to return an `Interpolation` object which contains the
interpolated string and a list of binding expressions.

3) Adds an optional third parameter to findElements and findBindings which makes
the returned list include only elements or both elements and nodes (in practice,
these are text nodes). This defaults to only returning elements.
