### PR TITLE
test(ng_model): reenable disabled test

### DIFF
--- a/test/directive/ng_model_spec.dart
+++ b/test/directive/ng_model_spec.dart
@@ -464,12 +464,7 @@ void main() {
       });
     });
 
-    // Test temporarily turned off.
-    // Typeless input fields work fine (tested manually).
-    // Also the test passes if ran by itself with ddescribe.
-    // TODO(radokirov): Find out the reason why this test fails when ran
-    // together with the whole testsuite.
-    xdescribe('no type attribute', () {
+    describe('no type attribute', () {
       it('should be set "text" as default value for "type" attribute', () {
         _.compile('<input ng-model="model">');
         _.rootScope.apply();


### PR DESCRIPTION
Seems to be fine with dart v1.7

Closes #1236
