### PR TITLE
chore(travis): fail jobs when e2e tests fail

### DIFF
--- a/scripts/run-e2e-test.sh
+++ b/scripts/run-e2e-test.sh
@@ -42,7 +42,7 @@ export -f _onSignal
 
 _initSignals() {
   for s in "${SIGNALS[@]}" ; do
-    trap "EXIT_CODE=$? ; _onSignal $s" $s
+    trap 'EXIT_CODE=$?'" ; _onSignal $s" $s
   done
 }
 export -f _initSignals


### PR DESCRIPTION
Note that this commit is actually going to cause Travis to fail since
the E2E tests are currently broken by passing due to issue #1528.  Once
this commit is in, I will submit #1527 to fix it.  These two commits
will serve as the test that this commit is actually doing the right
thing.

Closes #1528
