### PR TITLE
fix(RootScope): set the scope on ScopeAware root context

### DIFF
--- a/lib/core/scope.dart
+++ b/lib/core/scope.dart
@@ -773,6 +773,7 @@ class RootScope extends Scope {
     _zone.onError = (e, s, ls) => _exceptionHandler(e, s);
     _zone.onScheduleMicrotask = runAsync;
     cacheRegister.registerCache("ScopeWatchASTs", astCache);
+    if (context is ScopeAware) context.scope = this;
   }
 
   RootScope get rootScope => this;

--- a/test/core/scope_spec.dart
+++ b/test/core/scope_spec.dart
@@ -24,6 +24,18 @@ void main() {
           ..bind(ScopeStatsEmitter, toImplementation: MockScopeStatsEmitter);
     });
 
+    describe('Root context', () {
+      beforeEachModule((Module module) {
+        module.bind(Object, toImplementation: _RootContext);
+      });
+
+      it('should set the scope when RootContext is ScopeAware',
+          (RootScope rootScope, Object rootContext) {
+        expect(rootContext).toBeAnInstanceOf(_RootContext);
+        expect((rootContext as _RootContext).scope).toBe(rootScope);
+      });
+    });
+
     describe('AST Bridge', () {
       it('should watch field', (Logger logger, Map context, RootScope rootScope) {
         context['field'] = 'Worked!';
@@ -1750,4 +1762,8 @@ class UnstableList {
 
 class Foo {
   increment(x) => x+1;
+}
+
+class _RootContext implements ScopeAware {
+  var scope;
 }


### PR DESCRIPTION
fixes #1554 

Which is something promoted by our API doc: 

>  When a [Directive] or the root context class implements [ScopeAware] the scope setter will be called to set the [Scope] on this component.
