### PR TITLE
feat(routing): upgraded route_hierachical to 0.6.0 and added support for watchQueryParameters

### DIFF
--- a/lib/routing/routing.dart
+++ b/lib/routing/routing.dart
@@ -62,6 +62,7 @@ class RouteViewFactory {
             }
           },
           leave: cfg.leave,
+          watchQueryParameters: cfg.watchQueryParameters,
           mount: (Route mountRoute) {
             if (cfg.mount != null) {
               _configure(mountRoute, cfg.mount);
@@ -83,10 +84,11 @@ NgRouteCfg ngRoute({String path, String view, String viewHtml,
     Map<String, NgRouteCfg> mount, modules(), bool defaultRoute: false,
     RoutePreEnterEventHandler preEnter, RouteEnterEventHandler enter,
     RoutePreLeaveEventHandler preLeave, RouteLeaveEventHandler leave,
-    dontLeaveOnParamChanges: false}) =>
+    dontLeaveOnParamChanges: false, List<Pattern> watchQueryParameters}) =>
         new NgRouteCfg(path: path, view: view, viewHtml: viewHtml, mount: mount,
             modules: modules, defaultRoute: defaultRoute, preEnter: preEnter, preLeave: preLeave,
-            enter: enter, leave: leave, dontLeaveOnParamChanges: dontLeaveOnParamChanges);
+            enter: enter, leave: leave, dontLeaveOnParamChanges: dontLeaveOnParamChanges,
+            watchQueryParameters: watchQueryParameters);
 /**
  * Object containing route configuration parameters. Typically this class
  * is not used directly, but rather constructed via [ngRoute] factory function.
@@ -103,9 +105,11 @@ class NgRouteCfg {
   final RoutePreEnterEventHandler preEnter;
   final RoutePreLeaveEventHandler preLeave;
   final RouteLeaveEventHandler leave;
+  final List<Pattern> watchQueryParameters;
 
   NgRouteCfg({this.view, this.viewHtml, this.path, this.mount, this.modules, this.defaultRoute,
-       this.enter, this.preEnter, this.preLeave, this.leave, this.dontLeaveOnParamChanges});
+       this.enter, this.preEnter, this.preLeave, this.leave, this.dontLeaveOnParamChanges,
+       this.watchQueryParameters});
 }
 
 /**

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -92,7 +92,7 @@ packages:
   route_hierarchical:
     description: route_hierarchical
     source: hosted
-    version: "0.5.0"
+    version: "0.6.0"
   smoke:
     description: smoke
     source: hosted

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   intl: '>=0.8.7 <0.12.0'
   observe: '>=0.10.0+1 <0.11.0'
   perf_api: '>=0.0.9 <0.1.0'
-  route_hierarchical: '>=0.5.0 <0.6.0'
+  route_hierarchical: '>=0.6.0 <0.7.0'
 dev_dependencies:
   benchmark_harness: '>=1.0.0 <2.0.0'
   guinness: '>=0.1.9 <0.2.0'

--- a/test/routing/routing_spec.dart
+++ b/test/routing/routing_spec.dart
@@ -298,6 +298,34 @@ main() {
     }));
 
 
+    it('should use watchQueryParameters patterns for query params', async(() {
+      int preEnterCount = 0;
+      initRouter((Router router, RouteViewFactory views) {
+        views.configure({
+          'foo': ngRoute(
+              path: '/foo',
+              preEnter: (_) => preEnterCount++,
+              watchQueryParameters: ['foo']
+          ),
+        });
+      });
+
+      router.route('/foo');
+      microLeap();
+
+      expect(preEnterCount).toBe(1);
+
+      router.route('/foo?foo=bar');
+      microLeap();
+
+      expect(preEnterCount).toBe(2);
+
+      router.route('/foo?foo=bar&bar=baz');
+      microLeap();
+
+      expect(preEnterCount).toBe(2);
+    }));
+
     it('should clear view on leave an call leave callback', async(() {
       int leaveCount = 0;
       initRouter((Router router, RouteViewFactory views) {


### PR DESCRIPTION
BREAKING CHANGE:
Since route_hierachical 0.6.0 router no longer requires prefixing query param names with route name.
By default all query param changes will trigger route reload, but you can provide
a list of param patterns (via `watchQueryParameters` named param on addRoute) which
will be used to match (prefix match) param names that trigger route reloading.
