### PR TITLE
Correct spelling of "assignment"

### DIFF
--- a/lib/change_detection/ast_parser.dart
+++ b/lib/change_detection/ast_parser.dart
@@ -134,7 +134,7 @@ class _ExpressionVisitor implements syntax.Visitor {
     _notSupported("function's returing functions");
   }
   void visitAssign(syntax.Assign exp) {
-    _notSupported('assignement');
+    _notSupported('assignment');
   }
   void visitLiteral(syntax.Literal exp) {
     _notSupported('literal');


### PR DESCRIPTION
Fix misspelled "assignment" in exception message
