### PR TITLE
style(example): Corrected directory name in Todo example readme

### DIFF
--- a/example/README.todo.md
+++ b/example/README.todo.md
@@ -12,7 +12,7 @@ To run this demo, first clone the entire Angular.dart repository.
 Then, run `pub serve` in this directory:
 
 ```
-$ cd demo
+$ cd example
 $ pub serve
 ```
 


### PR DESCRIPTION
Currently example/README.todo.md states that you should run 'pub serve' in 'demo' directory, but seems that correct name is not 'demo' but 'example'.
