### PR TITLE
doc(application factory): fix the doc

### DIFF
--- a/lib/application_factory.dart
+++ b/lib/application_factory.dart
@@ -24,13 +24,6 @@ import 'dart:html';
  * If you are writing code accessed from Angular expressions, you must include
  * your own @MirrorsUsed annotation or ensure that everything is tagged with
  * the Ng annotations.
- *
- * All programs should also include a @MirrorsUsed(override: '*') which
- * tells the compiler that only the explicitly listed libraries will
- * be reflected over.
- *
- * This is a short-term fix until we implement a transformer-based solution
- * which does not rely on mirrors.
  */
 @MirrorsUsed(targets: const [
     'angular',


### PR DESCRIPTION
fixes #1586 

Remove some outdated doc.

The top-most comment in this file refer to the application-app library which has [an up to date documentation on static vs dynamic apps](https://github.com/angular/angular.dart/blob/0fbd007e0910fe421a9dc8b84da2ea92b2c7b768/lib/application.dart#L1).

/cc @vmendi
