### PR TITLE
fix(source_metadata_extractor): Fixed problem with processing Component and Decorator annotations when named import is used.

### DIFF
--- a/lib/tools/source_metadata_extractor.dart
+++ b/lib/tools/source_metadata_extractor.dart
@@ -95,6 +95,7 @@ class SourceMetadataExtractor {
 class DirectiveMetadataCollectingAstVisitor extends RecursiveAstVisitor {
   final List<DirectiveMetadata> metadata;
   final List<String> templates;
+  final RegExp _COMPONENT_OR_DECORATOR_EXPR = new RegExp(r"\.?(Component|Decorator)$");
 
   DirectiveMetadataCollectingAstVisitor(this.metadata, this.templates);
 
@@ -120,7 +121,8 @@ class DirectiveMetadataCollectingAstVisitor extends RecursiveAstVisitor {
       if (ann.arguments == null) return; // Ignore non-class annotations.
       // TODO(pavelj): this is not a safe check for the type of the
       // annotations, but good enough for now.
-      if (ann.name.name != 'Component' && ann.name.name != 'Decorator') return;
+      if (!_COMPONENT_OR_DECORATOR_EXPR.hasMatch(ann.name.name))
+        return;
 
       var meta = new DirectiveMetadata()..className = clazz.name.name;
       metadata.add(meta);

--- a/test/tools/transformer/expression_generator_spec.dart
+++ b/test/tools/transformer/expression_generator_spec.dart
@@ -177,6 +177,28 @@ main() {
             htmlFiles.clear();
           });
     });
+
+    it('should extract functions as getters when named import is used', () {
+      return generates(phases,
+          inputs: {
+            'a|web/main.dart': '''
+              import 'package:angular/angular.dart' as ng;
+
+              @ng.Component(selector: 'cmp', template: '{{foo}}')
+              class TestComponent {
+                String foo = "foo";
+              }
+
+              main() {} ''',
+            'a|web/index.html': '''
+              <cmp></cmp>
+              <script src='main.dart' type='application/dart'></script>''',
+            'angular|lib/angular.dart': libAngular,
+          },
+          getters: ['foo'],
+          setters: ['foo'],
+          symbols: []);
+    });
   });
 }
 


### PR DESCRIPTION
This change related to issue #1620. 
Please review if this solution is acceptable.
Thanks.