### PR TITLE
<feat>(expression_transformer): Parse NgTemplateCache values

### DIFF
--- a/lib/tools/transformer/expression_generator.dart
+++ b/lib/tools/transformer/expression_generator.dart
@@ -84,8 +84,7 @@ class ExpressionGenerator extends Transformer with ResolverTransformer {
         .toList();
 
     // Get all of the contents of templates in @Component(templateUrl:'...')
-    gatherReferencedUris(transform, resolver, options,
-        templatesOnly: true).then((templates) {
+    gatherReferencedUris(transform, resolver, options).then((templates) {
       templates.values.forEach(controller.add);
     }).then((_) {
       // Add any HTML files referencing this Dart file.

--- a/test/tools/transformer/expression_generator_spec.dart
+++ b/test/tools/transformer/expression_generator_spec.dart
@@ -92,6 +92,33 @@ main() {
           symbols: []);
     });
 
+    it('should follow template cache uris', () {
+      return generates(phases,
+          inputs: {
+            'a|web/main.dart': '''
+                import 'package:angular/angular.dart';
+                import 'package:angular/cacheAnnotation.dart';
+
+                @NgTemplateCache(
+                    preCacheUrls: ['lib/foo.html', 'packages/b/bar.html'])
+                class FooClass {}
+
+                main() {}
+                ''',
+            'a|lib/foo.html': '''
+                <div>{{template.contents}}</div>''',
+            'b|lib/bar.html': '''
+                <div>{{bar}}</div>''',
+            'a|web/index.html': '''
+                <script src='main.dart' type='application/dart'></script>''',
+            'angular|lib/angular.dart': libAngular,
+            'angular|lib/cacheAnnotation.dart': libCacheAnnotation,
+          },
+          getters: ['template', 'contents', 'bar'],
+          setters: ['template', 'contents', 'bar'],
+          symbols: []);
+    });
+
     it('should generate expressions for variables found in superclass', () {
       return generates(phases,
       inputs: {
@@ -246,5 +273,13 @@ class Component {
 class NgAttr {
   final _mappingSpec = '@';
   const NgAttr(String attrName);
+}
+''';
+
+const String libCacheAnnotation = '''
+library angular.template_cache_annotation;
+
+class NgTemplateCache {
+  const NgTemplateCache({List preCacheUrls, bool cache});
 }
 ''';


### PR DESCRIPTION
Parse html files from NgTemplateCache annotations for expressions, allowing developers the ease
of including files needed to be parsed without specifying them individually in the pubspec.yaml
definition.

Closes #1644