### PR TITLE
<fix>(resource_url_resolver): Makes resolved URLs absolute

### DIFF
--- a/lib/core_dom/resource_url_resolver.dart
+++ b/lib/core_dom/resource_url_resolver.dart
@@ -160,13 +160,11 @@ class ResourceUrlResolver {
     // If it's not absolute, then resolve it first
     Uri resolved = baseUri.resolve(uri);
 
-    // If it's package-relative, tack on 'packages/' - Note that eventually
-    // we may want to change this to be '/packages/' to make it truly absolute
+    // If it's package-relative, tack on '/packages/'
     if (resolved.scheme == 'package') {
-      return 'packages/${resolved.path}';
+      return '/packages/${resolved.path}';
     } else if (resolved.isAbsolute && resolved.toString().startsWith(_baseUri)) {
-      var path = resolved.path;
-      return path.startsWith("/") ? path.substring(1) : path;
+      return resolved.path;
     } else {
       return resolved.toString();
     }

--- a/test/_specs.dart
+++ b/test/_specs.dart
@@ -47,7 +47,7 @@ e(String html) => es(html).first;
 // this file, _specs.dart, is at path /base/test/_specs.dart.  However, if
 // you're using a different test server or reconfigured the base prefix, then
 // you can set this to something different.
-String TEST_SERVER_BASE_PREFIX = "base/";
+String TEST_SERVER_BASE_PREFIX = "/base/";
 
 Expect expect(actual, [matcher]) {
   final expect = new Expect(actual);

--- a/test/core/templateurl_spec.dart
+++ b/test/core/templateurl_spec.dart
@@ -85,7 +85,7 @@ void shadowDomAndTranscluding(name, fn) {
 _run({resolveUrls, staticMode}) {
   var prefix;
   if (!resolveUrls) prefix = "";
-  else if (staticMode) prefix = "packages/test.angular.core_dom/";
+  else if (staticMode) prefix = "/packages/test.angular.core_dom/";
   else prefix = TEST_SERVER_BASE_PREFIX + "test/core/";
 
   describe('template url resolveUrls=${resolveUrls}, mode=${staticMode ? 'static' : 'dynamic'}', () {

--- a/test/core_dom/resource_url_resolver_spec.dart
+++ b/test/core_dom/resource_url_resolver_spec.dart
@@ -195,18 +195,18 @@ _run_resolver({useRelativeUrls}) {
 
     testBothSchemes(
         urlToResolve:             'package:a.b/c/d/foo2.html',
-        expectedForPackageScheme: 'packages/a.b/c/d/foo2.html',
-        expectedForHttpScheme:    'packages/a.b/c/d/foo2.html');
+        expectedForPackageScheme: '/packages/a.b/c/d/foo2.html',
+        expectedForHttpScheme:    '/packages/a.b/c/d/foo2.html');
 
     testBothSchemes(
         urlToResolve:             'image.png',
-        expectedForPackageScheme: 'packages/angular/test/core_dom/image.png',
-        expectedForHttpScheme:    'a/b/image.png');
+        expectedForPackageScheme: '/packages/angular/test/core_dom/image.png',
+        expectedForHttpScheme:    '/a/b/image.png');
 
     testBothSchemes(
         urlToResolve:             './image2.png',
-        expectedForPackageScheme: 'packages/angular/test/core_dom/image2.png',
-        expectedForHttpScheme:    'a/b/image2.png');
+        expectedForPackageScheme: '/packages/angular/test/core_dom/image2.png',
+        expectedForHttpScheme:    '/a/b/image2.png');
 
     testBothSchemes(
         urlToResolve:             '/image3.png',
@@ -225,13 +225,13 @@ _run_resolver({useRelativeUrls}) {
 
     testBothSchemes(
         urlToResolve:             'HTTP://LOCALHOST/a/b/image4.png',
-        expectedForPackageScheme: 'a/b/image4.png',
-        expectedForHttpScheme:    'a/b/image4.png');
+        expectedForPackageScheme: '/a/b/image4.png',
+        expectedForHttpScheme:    '/a/b/image4.png');
 
     testBothSchemes(
         urlToResolve:             'HTTP://LOCALHOST/packages/angular/test/core_dom/foo3.html',
-        expectedForPackageScheme: 'packages/angular/test/core_dom/foo3.html',
-        expectedForHttpScheme:    'packages/angular/test/core_dom/foo3.html');
+        expectedForPackageScheme: '/packages/angular/test/core_dom/foo3.html',
+        expectedForHttpScheme:    '/packages/angular/test/core_dom/foo3.html');
 
   });
 }


### PR DESCRIPTION

Makes resolved type URLs absolute instead of relative. When they are relative
it is difficult to reuse components. Using pub serve relative URLs are resolved
because pub does some magic to allow add symlinks to the packages directory
where needed. In production relative URLs make it difficult to add file handlers
to the locations that are needed, as the location will be determined based on
the current browser path or route. It also makes the template cache harder to
populate because the same resource may need to be served from two separate
URLs.

Closes #1599