### PR TITLE
<fix>(transformers): Fix relative URL lookup for transformers, and web assets

### DIFF
--- a/lib/tools/transformer/transformer_resource_url_resolver.dart
+++ b/lib/tools/transformer/transformer_resource_url_resolver.dart
@@ -1,0 +1,62 @@
+library angular.tools.transformer.angular_file_resolver;
+
+import 'package:analyzer/src/generated/element.dart';
+import 'package:code_transformers/resolver.dart';
+import 'package:barback/barback.dart';
+
+/// Resolver used to find absolute resources when in Transformers by combining
+/// AST element locations and relative URIs.
+class TransformerResourceUrlResolver {
+  final Resolver _resolver;
+  final AssetId _primaryAsset;
+
+  TransformerResourceUrlResolver(this._resolver, this._primaryAsset);
+
+  Uri findUriOfElement(Element type) {
+    var uri = _resolver.getImportUri(type.library, from: _primaryAsset);
+    var acceptable = (
+        (uri.isAbsolute && uri.scheme == 'package') ||
+        (uri.toString() == uri.path));
+    if (!acceptable) {
+      var errMsg = 'ERROR: Type "$type" has unsupported URI $uri';
+      throw errMsg;
+    }
+    if (uri.scheme != "package") {
+      // this is guaranteed to be a relative URL (e.g. type defined in a path
+      // imported file)
+      var path = _primaryAsset.path;
+      if (!path.startsWith('web/')) {
+        var errMsg = 'ERROR: Type "$type" is imported as a path not under web.';
+        throw errMsg;
+      }
+      uri = Uri.parse(path.substring('web/'.length)).resolve(uri.path);
+    }
+    return uri;
+  }
+
+  /// Given a AST [type] and [uri] if [uri] is relative combines it with the uri
+  /// of the element to make an absolute location relative to types uri.
+  /// Note: This logic should match [ResourceUrlResolver], but is separate as
+  /// transformers and Mirrors have different APIs to identify elements, and
+  /// calculate their URIs.
+  String combineWithElement(Element type, String uri) {
+    if (uri != null) {
+      if (uri.startsWith("/")) return uri;
+      if (uri.startsWith("packages/")) return "/" + uri;
+    }
+
+    var typeUri = findUriOfElement(type);
+
+    if (uri == null) {
+      uri = typeUri.path;
+    }
+    // If it's not absolute, then resolve it first
+    Uri resolved = typeUri.resolve(uri);
+
+    if (resolved.scheme == 'package') {
+      return '/packages/${resolved.path}';
+    } else {
+      return resolved.toString();
+    }
+  }
+}

--- a/test/tools/transformer/expression_generator_spec.dart
+++ b/test/tools/transformer/expression_generator_spec.dart
@@ -68,7 +68,7 @@ main() {
                 import 'package:angular/angular.dart';
 
                 @Component(
-                    templateUrl: 'lib/foo.html',
+                    templateUrl: 'foo.html',
                     selector: 'my-component')
                 class FooComponent {}
 
@@ -79,7 +79,7 @@ main() {
 
                 main() {}
                 ''',
-            'a|lib/foo.html': '''
+            'a|web/foo.html': '''
                 <div>{{template.contents}}</div>''',
             'b|lib/bar.html': '''
                 <div>{{bar}}</div>''',
@@ -92,6 +92,33 @@ main() {
           symbols: []);
     });
 
+    it('should respect relative URLs', () {
+      return generates(phases,
+          inputs: {
+            'a|web/main.dart': '''
+                import 'package:b/bar.dart';
+
+                main() {}
+                ''',
+            'b|lib/bar.dart': '''
+                import 'package:angular/angular.dart';
+
+                @Component(
+                    templateUrl: 'bar.html',
+                    selector: 'my-component')
+                class BarComponent {}
+                ''',
+            'b|lib/bar.html': '''
+                <div>{{bar}}</div>''',
+            'a|web/index.html': '''
+                <script src='main.dart' type='application/dart'></script>''',
+            'angular|lib/angular.dart': libAngular,
+          },
+          getters: ['bar'],
+          setters: ['bar'],
+      symbols: []);
+    });
+
     it('should generate expressions for variables found in superclass', () {
       return generates(phases,
       inputs: {
@@ -99,7 +126,7 @@ main() {
                 import 'package:angular/angular.dart';
 
                 @Component(
-                    templateUrl: 'lib/foo.html',
+                    templateUrl: 'foo.html',
                     selector: 'my-component')
                 class FooComponent extends BarComponent {
                   @NgAttr('foo')
@@ -113,7 +140,7 @@ main() {
 
                 main() {}
                 ''',
-          'a|lib/foo.html': '''
+          'a|web/foo.html': '''
                 <div>{{template.foo}}</div>
                 <div>{{template.bar}}</div>''',
           'a|web/index.html': '''


### PR DESCRIPTION
Extracts logic used in the TypeRelativeUriGenerator to be used in other
transformers. This allows other transformers such as the ExpressionGenerator
and later the TemplateCacheGenerator to find relative resources.

Closes #1649