### PR TITLE
<fix>(transformers): Fix asset resolution for web assets

### DIFF
--- a/lib/tools/transformer/referenced_uris.dart
+++ b/lib/tools/transformer/referenced_uris.dart
@@ -212,7 +212,10 @@ class _Processor {
       warn('Cannot cache non-package absolute URIs. $uri', reference);
       return null;
     }
-    var assetId = new AssetId(transform.primaryInput.id.package, uri);
+    // Everything else is a resource in the web directory according to pub;
+    // as all packages URIs were handled above. As specified in this
+    // [Barback Doc](http://goo.gl/YDMRc2)
+    var assetId = new AssetId(transform.primaryInput.id.package, 'web/$uri');
     return new _CacheEntry(uri, reference, assetId);
   }
 

--- a/test/tools/transformer/expression_generator_spec.dart
+++ b/test/tools/transformer/expression_generator_spec.dart
@@ -68,7 +68,7 @@ main() {
                 import 'package:angular/angular.dart';
 
                 @Component(
-                    templateUrl: 'lib/foo.html',
+                    templateUrl: 'foo.html',
                     selector: 'my-component')
                 class FooComponent {}
 
@@ -79,7 +79,7 @@ main() {
 
                 main() {}
                 ''',
-            'a|lib/foo.html': '''
+            'a|web/foo.html': '''
                 <div>{{template.contents}}</div>''',
             'b|lib/bar.html': '''
                 <div>{{bar}}</div>''',
@@ -99,7 +99,7 @@ main() {
                 import 'package:angular/angular.dart';
 
                 @Component(
-                    templateUrl: 'lib/foo.html',
+                    templateUrl: 'foo.html',
                     selector: 'my-component')
                 class FooComponent extends BarComponent {
                   @NgAttr('foo')
@@ -113,7 +113,7 @@ main() {
 
                 main() {}
                 ''',
-          'a|lib/foo.html': '''
+          'a|web/foo.html': '''
                 <div>{{template.foo}}</div>
                 <div>{{template.bar}}</div>''',
           'a|web/index.html': '''


### PR DESCRIPTION
Fixes asset resolution according to Barback rules which are defined here:
http://goo.gl/YDMRc2 specifically library assets are defined with packages
being in the URI and all other resources are considered web resources.

Closes #1651