### PR TITLE
<fix>(transformers): Fix test of expression_spec

### DIFF
--- a/lib/core_dom/type_to_uri_mapper_dynamic.dart
+++ b/lib/core_dom/type_to_uri_mapper_dynamic.dart
@@ -10,6 +10,13 @@ class DynamicTypeToUriMapper extends TypeToUriMapper {
   Uri uriForType(Type type) {
     var typeMirror = reflectType(type);
     LibraryMirror lib = typeMirror.owner;
+    // LibraryMirror should produce absolute URIs but due to bug:
+    // http://dartbug.com/22249 dart2js produces relative URIs. Change to an
+    // absolute path.
+    // TODO(tsander): Remove this code when bug is fixed.
+    if (!lib.uri.isAbsolute && !lib.uri.path.startsWith("/")) {
+      return Uri.parse("/${lib.uri.path}");
+    }
     return lib.uri;
   }
 }

--- a/test/tools/transformer/expression_generator_spec.dart
+++ b/test/tools/transformer/expression_generator_spec.dart
@@ -100,7 +100,7 @@ main() {
                 import 'package:angular/cacheAnnotation.dart';
 
                 @NgTemplateCache(
-                    preCacheUrls: ['lib/foo.html', 'packages/b/bar.html'])
+                    preCacheUrls: ['packages/a/foo.html', 'packages/b/bar.html'])
                 class FooClass {}
 
                 main() {}


### PR DESCRIPTION
Fix expression_generator_spec by removing deprecated lib syntax for relative uris, and using package syntax instead. Fix dart2js test by fixing bug in DynamicTypeToUriMapper.