### PR TITLE
refactor(ngControl, ngModel) : add type annotations

### DIFF
--- a/lib/directive/ng_control.dart
+++ b/lib/directive/ng_control.dart
@@ -8,13 +8,13 @@ part of angular.directive;
  * user input with NgModel.
  */
 abstract class NgControl implements AttachAware, DetachAware {
-  static const NG_INVALID        = "ng-invalid";
-  static const NG_PRISTINE       = "ng-pristine";
-  static const NG_DIRTY          = "ng-dirty";
-  static const NG_TOUCHED        = "ng-touched";
-  static const NG_UNTOUCHED      = "ng-untouched";
-  static const NG_SUBMIT_VALID   = "ng-submit-valid";
-  static const NG_SUBMIT_INVALID = "ng-submit-invalid";
+  static const String NG_INVALID        = "ng-invalid";
+  static const String NG_PRISTINE       = "ng-pristine";
+  static const String NG_DIRTY          = "ng-dirty";
+  static const String NG_TOUCHED        = "ng-touched";
+  static const String NG_UNTOUCHED      = "ng-untouched";
+  static const String NG_SUBMIT_VALID   = "ng-submit-valid";
+  static const String NG_SUBMIT_INVALID = "ng-submit-invalid";
 
   String _name;
   bool _submitValid;
@@ -30,13 +30,13 @@ abstract class NgControl implements AttachAware, DetachAware {
     * The list of errors present on the control represented by an error name and
     * an inner control instance.
     */
-  final errorStates = new Map<String, Set<NgControl>>();
+  final Map<String, Set<NgControl>> errorStates = new Map<String, Set<NgControl>>();
 
   /**
     * The list of info messages present on the control represented by an state name and
     * an inner control instance.
     */
-  final infoStates = new Map<String, Set<NgControl>>();
+  final Map<String, Set<NgControl>> infoStates = new Map<String, Set<NgControl>>();
 
   NgControl(NgElement this._element, DirectiveInjector injector,
       Animate this._animate)

--- a/lib/directive/ng_model.dart
+++ b/lib/directive/ng_model.dart
@@ -482,11 +482,11 @@ class InputNumberLike {
 @Decorator(selector: 'input[type=month][ng-model][ng-bind-type]', visibility: Visibility.LOCAL)
 @Decorator(selector: 'input[type=week][ng-model][ng-bind-type]', visibility: Visibility.LOCAL)
 class NgBindTypeForDateLike {
-  static const DATE = 'date';
-  static const NUMBER = 'number';
-  static const STRING = 'string';
-  static const DEFAULT = DATE;
-  static const VALID_VALUES = const <String>[DATE, NUMBER, STRING];
+  static const String DATE = 'date';
+  static const String NUMBER = 'number';
+  static const String STRING = 'string';
+  static const String DEFAULT = DATE;
+  static const List<String> VALID_VALUES = const <String>[DATE, NUMBER, STRING];
 
   final dom.InputElement inputElement;
   String _idlAttrKind = DEFAULT;


### PR DESCRIPTION
Added type annotations on public fields for ng_control and ng_model as described in issue #853.
All other public fields in the other directives followed these rules, but the public fields here adjusted didn't.