### PR TITLE
feat(transformers): Allow more complicated package uris

### DIFF
--- a/test/tools/transformer/all.dart
+++ b/test/tools/transformer/all.dart
@@ -4,10 +4,12 @@ import 'expression_generator_spec.dart' as expression_generator_spec;
 import 'metadata_generator_spec.dart' as metadata_generator_spec;
 import 'static_angular_generator_spec.dart' as static_angular_generator_spec;
 import 'type_relative_uri_generator_spec.dart' as type_relative_uri_generator_spec;
+import 'template_cache_generator_spec.dart' as template_cache_generator_spec;
 
 main() {
   expression_generator_spec.main();
   metadata_generator_spec.main();
   static_angular_generator_spec.main();
   type_relative_uri_generator_spec.main();
+  template_cache_generator_spec.main();
 }

--- a/test/tools/transformer/template_cache_generator_spec.dart
+++ b/test/tools/transformer/template_cache_generator_spec.dart
@@ -185,6 +185,44 @@ main() {
             'angular|lib/template_cache.dart': libCacheAnnotation,
       });
     });
+
+    it('should cache complicated URLs', () {
+      return generates(setupPhases(),
+          inputs: {
+              'a|web/main.dart': '''
+                    import 'package:angular/angular.dart';
+                    import 'dir/foo.dart';
+
+                    // Packages can be anywhere in the uri.
+                    @Component(templateUrl: "/x/y/z/packages/a.b.c/test1.html",
+                        cssUrl: "/packages/b/test1.css")
+                    class A {}
+
+                    main() {}
+              ''',
+              'a|web/dir/foo.dart': '''
+                    import 'package:angular/angular.dart';
+
+                    // Packages may show up multiple times. Only the last value
+                    // will be an identifier. Deeper paths after packages work.
+                    @Component(
+                        templateUrl: "/a/packages/z/packages/a/dir/test2.html",
+                        cssUrl: "/packages/y/dir/dir2/dir3/test2.css")
+                    class B {}
+              ''',
+              'a.b.c|lib/test1.html': htmlContent1,
+              'a|lib/dir/test2.html': htmlContent2,
+              'angular|lib/angular.dart': libAngular,
+              'b|lib/test1.css': cssContent1,
+              'y|lib/dir/dir2/dir3/test2.css': cssContent2,
+          },
+          cacheContent: {
+              '/x/y/z/packages/a.b.c/test1.html': htmlContent1,
+              '/packages/b/test1.css': cssContent1,
+              '/a/packages/z/packages/a/dir/test2.html': htmlContent2,
+              '/packages/y/dir/dir2/dir3/test2.css': cssContent2,
+      });
+    });
   });
 }
 

--- a/test/tools/transformer/template_cache_generator_spec.dart
+++ b/test/tools/transformer/template_cache_generator_spec.dart
@@ -14,6 +14,8 @@ main() {
   describe('TemplateCacheGenerator', () {
     var htmlContent1 = "<div></div>";
     var htmlContent2 = "<span></span>";
+    var cssContent1 = '#id {color: red}';
+    var cssContent2 = '#id2 {color: blue}';
 
     it('should cache templateURL', () {
       return generates(setupPhases(),
@@ -33,19 +35,17 @@ main() {
                 @Component(templateUrl: "test2.html")
                 class B {}
             ''',
-            'a|test1.html': htmlContent1,
-            'a|test2.html': htmlContent2,
+            'a|web/test1.html': htmlContent1,
+            'a|web/dir/test2.html': htmlContent2,
             'angular|lib/angular.dart': libAngular,
           },
           cacheContent: {
             'test1.html': htmlContent1,
-            'test2.html': htmlContent2,
+            'dir/test2.html': htmlContent2,
           });
     });
 
     it('should cache cssURLs', () {
-      var cssContent1 = '#id {color: red}';
-      var cssContent2 = '#id2 {color: blue}';
       return generates(setupPhases(),
       inputs: {
           'a|web/main.dart': '''
@@ -63,13 +63,13 @@ main() {
                 @Component(cssUrl: ["test2.css"])
                 class B {}
             ''',
-          'a|test1.css': cssContent1,
-          'a|test2.css': cssContent2,
+          'a|web/test1.css': cssContent1,
+          'a|web/dir/test2.css': cssContent2,
           'angular|lib/angular.dart': libAngular,
       },
       cacheContent: {
           'test1.css': cssContent1,
-          'test2.css': cssContent2,
+          'dir/test2.css': cssContent2,
       });
     });
 
@@ -93,8 +93,8 @@ main() {
 
                  main() {}
                  ''',
-            'a|multiline1.html': multiLineContent1,
-            'a|multiline2.css': multiLineContent2,
+            'a|web/multiline1.html': multiLineContent1,
+            'a|web/multiline2.css': multiLineContent2,
             'angular|lib/angular.dart': libAngular,
           },
           cacheContent: {
@@ -123,14 +123,14 @@ main() {
                 @NgTemplateCache(preCacheUrls: ["test2.html"])
                 class B {}
             ''',
-            'a|test1.html': htmlContent1,
-            'a|test2.html': htmlContent2,
+            'a|web/test1.html': htmlContent1,
+            'a|web/dir/test2.html': htmlContent2,
             'angular|lib/angular.dart': libAngular,
             'angular|lib/angular_cache.dart': libCacheAnnotation,
           },
           cacheContent: {
             'test1.html': htmlContent1,
-            'test2.html': htmlContent2,
+            'dir/test2.html': htmlContent2,
           });
     });
 
@@ -181,8 +181,8 @@ main() {
                 @NgTemplateCache(preCacheUrls: ["test2.html"])
                 class B {}
             ''',
-          'angular|lib/angular.dart': libAngular,
-          'angular|lib/template_cache.dart': libCacheAnnotation,
+            'angular|lib/angular.dart': libAngular,
+            'angular|lib/template_cache.dart': libCacheAnnotation,
       });
     });
   });


### PR DESCRIPTION
Allow /packages/ identifier to appear anywhere in a uri and parse the AssetId correctly.

This is dependent on my pull request here #1686