### PR TITLE
Fixed null pointer bug in _revertToPreviousState

### DIFF
--- a/lib/change_detection/dirty_checking_change_detector.dart
+++ b/lib/change_detection/dirty_checking_change_detector.dart
@@ -1001,7 +1001,7 @@ class _CollectionChangeRecord<V> implements CollectionChangeRecord<V> {
       _linkedRecords.put(record);
     }
 
-    prev._next = null;
+    if (prev != null) prev._next = null;
     _itTail = prev;
     _undoDeltas();
   }


### PR DESCRIPTION
If i==0 (didn't go through the loop at all), prev would be null and
prev._next would result in a null pointer exception.