### PR TITLE
chore(pubspec): Widen the analyzer constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ homepage: https://angulardart.org
 environment:
   sdk: '>=1.4.0'
 dependencies:
-  analyzer: '>=0.22.0 <0.23.0'
+  analyzer: '>=0.22.0 <0.25.0'
   args: '>=0.12.0 <0.13.0'
   barback: '>=0.13.0 <0.17.0'
   browser: '>=0.10.0 <0.11.0'
@@ -23,7 +23,7 @@ dependencies:
   di: '>=3.3.3 <4.0.0'
   html5lib: '>=0.12.0 <0.13.0'
   intl: '>=0.8.7 <0.12.0'
-  observe: '>=0.12.0 <0.13.0'
+  observe: '>=0.12.0 <0.14.0'
   perf_api: '>=0.0.9 <0.1.0'
   route_hierarchical: '>=0.6.1 <0.7.0'
 dev_dependencies:

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -24,7 +24,13 @@ for FILE in $(ls lib/angular.dart \
                  lib/change_detection/watch_group.dart \
              )
 do
-  echo export \'../$FILE\' hide main, NestedRouteInitializer\; >> $OUT
+  # Use `package:` imports where possible to avoid ambiguous resolution.
+  if [[ $FILE == lib* ]]; then
+    FILE=$(echo $FILE | sed -e 's!lib\(.*\)!package:angular\1!')
+  else
+    FILE=../$FILE
+  fi
+  echo export \'$FILE\' hide main, NestedRouteInitializer\; >> $OUT
 done
 
 $NGDART_SCRIPT_DIR/generate-expressions.sh


### PR DESCRIPTION
Allow use of package:analyzer <0.25.0. Analyzer earlier than 0.24.0 has
issues with parsing `async` and `await`, this allows the use of
Angular.dart with code that needs process such code with analyzer.