### PR TITLE
Fixes an issue with the generated_template_cache.

### DIFF
--- a/lib/tools/transformer/static_angular_generator.dart
+++ b/lib/tools/transformer/static_angular_generator.dart
@@ -102,7 +102,7 @@ class _NgDynamicToStaticVisitor extends GeneralizingAstVisitor {
         transaction.edit(
             m.end,
             m.end,
-            '..addModule(generated_template_cache.templateCacheModule)');
+            '.addModule(generated_template_cache.templateCacheModule)');
       }
     }
     super.visitMethodInvocation(m);

--- a/test/tools/transformer/static_angular_generator_spec.dart
+++ b/test/tools/transformer/static_angular_generator_spec.dart
@@ -79,7 +79,7 @@ import 'main_generated_template_cache.dart' as generated_template_cache;
 class MyModule extends Module {}
 
 main() {
-  var app = staticApplicationFactory(generated_static_metadata.typeAnnotations, generated_static_expressions.getters, generated_static_expressions.setters, generated_static_expressions.symbols, generated_static_type_to_uri_mapper.typeToUriMapper)..addModule(generated_template_cache.templateCacheModule)
+  var app = staticApplicationFactory(generated_static_metadata.typeAnnotations, generated_static_expressions.getters, generated_static_expressions.setters, generated_static_expressions.symbols, generated_static_type_to_uri_mapper.typeToUriMapper).addModule(generated_template_cache.templateCacheModule)
     .addModule(new MyModule())
     .run();
 }
@@ -117,7 +117,7 @@ import 'main_generated_template_cache.dart' as generated_template_cache;
 class MyModule extends Module {}
 
 main() {
-  var app = ng.staticApplicationFactory(generated_static_metadata.typeAnnotations, generated_static_expressions.getters, generated_static_expressions.setters, generated_static_expressions.symbols, generated_static_type_to_uri_mapper.typeToUriMapper)..addModule(generated_template_cache.templateCacheModule)
+  var app = ng.staticApplicationFactory(generated_static_metadata.typeAnnotations, generated_static_expressions.getters, generated_static_expressions.setters, generated_static_expressions.symbols, generated_static_type_to_uri_mapper.typeToUriMapper).addModule(generated_template_cache.templateCacheModule)
     .addModule(new MyModule())
     .run();
 }


### PR DESCRIPTION
Given the code ng.applicationFactory().addModule(myModule).run(), this
is rewritten into
ng.staticApplicationFactory(...)..addModule(generated_template_cache).addModule(myModule).run().

The original expression evaluates to an Injector, but the rewritten
expression evaluates to to the StaticApplication object. Since addModule
already returns this, its not needed to use .., so I've removed it,
restoring the correct evaluated object.