### PR TITLE
fix(ng_class): fix space-handling in css classes.

### DIFF
--- a/lib/directive/ng_class.dart
+++ b/lib/directive/ng_class.dart
@@ -211,7 +211,8 @@ abstract class _NgClassBase {
       _computeMapChanges(value, _first);
     } else {
       if (value is String) {
-        _currentSet..clear()..addAll(value.split(' '));
+        var values = value.split(' ').where((c) => c.isNotEmpty);
+        _currentSet..clear()..addAll(values);
       } else if (value == null) {
         _currentSet.clear();
       } else {

--- a/test/directive/ng_class_spec.dart
+++ b/test/directive/ng_class_spec.dart
@@ -94,6 +94,19 @@ main() {
       expect(element).toHaveClass('B');
     });
 
+    it('should handle empty class strings', () {
+      var element = _.compile('<div class="existing" ng-class="\'\'"></div>');
+      _.rootScope.apply();
+      expect(element).toHaveClass('existing');
+    });
+
+    it('should gracefully handle extraneous whitespace', () {
+      var element = _.compile('<div class="existing" ng-class="\' A  B   \'"></div>');
+      _.rootScope.apply();
+      expect(element).toHaveClass('existing');
+      expect(element).toHaveClass('A');
+      expect(element).toHaveClass('B');
+    });
 
     it('should preserve class added post compilation with pre-existing classes', () {
       var element = _.compile('<div class="existing" ng-class="dynClass"></div>');


### PR DESCRIPTION
As of SDK 1.10, dart:html _ElementCssClassSet.add() requires valid CSS class names. This change ensures proper whitespace handling for values such as "  foo  bar baz   ".