### PR TITLE
fix(shadow_dom_emulation): fix content reprojection bug.

### DIFF
--- a/lib/core_dom/light_dom.dart
+++ b/lib/core_dom/light_dom.dart
@@ -87,7 +87,7 @@ class LightDom implements SourceLightDom, DestinationLightDom {
     for(final root in _lightDomRootNodes) {
       if (_ports.containsKey(root)) {
         list.addAll(_ports[root].nodes);
-      } else if (root is dom.ContentElement) {
+      } else if (isContentElement(root)) {
         if (!_contentTags.containsKey(root))
           throw new Exception('Unmatched content tag encountered during redistibution.');
         list.addAll(_contentTags[root].nodes);
@@ -97,6 +97,8 @@ class LightDom implements SourceLightDom, DestinationLightDom {
     }
     return list;
   }
+
+  static isContentElement(dom.Node node) => node is dom.Element && node.tagName == 'CONTENT';
 }
 
 void redistributeNodes(Iterable<Content> contents, List<dom.Node> nodes) {


### PR DESCRIPTION
On non-shadow DOM enabled browsers content tag cannot be checked by
using the type of the element. Instead the tagName should be used.