### PR TITLE
fix(css): add empty class check to NgElement.

### DIFF
--- a/lib/core_dom/ng_element.dart
+++ b/lib/core_dom/ng_element.dart
@@ -36,12 +36,14 @@ class NgElement {
 
   /// Schedules a DOM write adding [className] to the element.
   void addClass(String className) {
+    if (className.isEmpty) return;
     _scheduleDomWrite();
     _classesToUpdate[className] = true;
   }
 
   /// Schedules a DOM write removing [className] from the element.
   void removeClass(String className) {
+    if (className.isEmpty) return;
     _scheduleDomWrite();
     _classesToUpdate[className] = false;
   }

--- a/test/core_dom/ng_element_spec.dart
+++ b/test/core_dom/ng_element_spec.dart
@@ -18,7 +18,7 @@ void main() {
         var element = e('<div></div>');
         var ngElement = new NgElement(element, scope, animate);
 
-        ngElement..addClass('one')..addClass('two three');
+        ngElement..addClass('one')..addClass('two')..addClass('three');
 
         ['one', 'two', 'three'].forEach((className) {
           expect(element).not.toHaveClass(className);
@@ -52,6 +52,19 @@ void main() {
           expect(element).not.toHaveClass(className);
         });
         expect(element).toHaveClass('four');
+      });
+
+      it('should ignore empty strings',
+          (TestBed _, Animate animate) {
+
+        var scope = _.rootScope;
+        var element = e('<div></div>');
+        var ngElement = new NgElement(element, scope, animate);
+
+        ngElement..addClass('');
+        ngElement..removeClass('');
+
+        scope.apply();
       });
 
       it('should always apply the last dom operation on the given className',


### PR DESCRIPTION
Dart2js 1.10 started passes classNames through without performing empty string
check. DOM apis throw on empty string, so we perform the empty class
name check inside our APIs.