### PR TITLE
feat(parser): include the expression that caused an exception during evaluation in the unwrapped error message

### DIFF
--- a/lib/core/parser/parser.dart
+++ b/lib/core/parser/parser.dart
@@ -117,6 +117,8 @@ class _UnwrapExceptionDecorator extends Expression {
       return _expression.eval(scope, formatters);
     } on EvalError catch (e, s) {
       throw e.unwrap("$this", s);
+    } catch (e, s) {
+      throw new EvalError(e.toString()).unwrap("$this", s);
     }
   }
 


### PR DESCRIPTION
This greatly improves debugging of angular.dart apps because it makes it much easier to find the expression that triggered an exception in the actual source code.