### PR TITLE
fix(css_shim): escape keyframes from shimming.

### DIFF
--- a/test/core_dom/css_shim_spec.dart
+++ b/test/core_dom/css_shim_spec.dart
@@ -52,6 +52,18 @@ main() {
       expect(s(css, "a")).toEqual(expected);
     });
 
+    it("should handle keyframe rules", () {
+      final css = "@keyframes foo {0% {transform: translate(-50%) scaleX(0)}}";
+
+      expect(s(css, "a")).toEqual(css);
+    });
+
+    it("should handle -webkit-keyframe rules", () {
+      final css = "@-webkit-keyframes foo {0% {transform: translate(-50% scaleX(0)}}";
+
+      expect(s(css, "a")).toEqual(css);
+    });
+
     it("should handle complicated selectors", () {
       expect(s('one::before {}', "a")).toEqual('one[a]::before {}');
       expect(s('one two {}', "a")).toEqual('one[a] two[a] {}');


### PR DESCRIPTION
@keyframes declaration changes the CSS syntax expected in ways, which
make it harder to shim. For now we just skip shimming the keyframe
names, as to keep valid CSS.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/angular.dart/1726)
<!-- Reviewable:end -->
