### PR TITLE
Fix typo in example usage of module function.

### DIFF
--- a/lib/mock/test_injection.dart
+++ b/lib/mock/test_injection.dart
@@ -123,7 +123,7 @@ inject(Function fn) {
  * repeatedly, as long as [inject] is not called. Invocation of [inject] creates the injector and
  * hence no more calls to [module] can be made.
  *
- *     setUp(module((Module model) {
+ *     setUp(module((Module module) {
  *       module.bind(Foo);
  *     });
  *


### PR DESCRIPTION
s/model/module/