### PR TITLE
Strips comments from css before applying css shim.

### DIFF
--- a/lib/core_dom/css_shim.dart
+++ b/lib/core_dom/css_shim.dart
@@ -52,6 +52,10 @@ String shimCssText(String css, String tag) =>
 class _CssShim {
   static final List SELECTOR_SPLITS = const [' ', '>', '+', '~'];
 
+  static final RegExp COMMENTS = new RegExp(
+    // Taken from http://www.w3.org/TR/CSS2/grammar.html#scanner.
+    r"\/\*[^*]*\*+([^/*][^*]*\*+)*\/");
+
   static final RegExp CONTENT = new RegExp(
       r"[^}]*"
       r"content:\s*"
@@ -92,10 +96,13 @@ class _CssShim {
       : tag = tag, attr = "[$tag]";
 
   String shimCssText(String css) {
-    final preprocessed = convertColonHost(css);
+    final preprocessed = convertColonHost(stripComments(css));
     final rules = cssToRules(preprocessed);
     return scopeRules(rules);
   }
+
+  String stripComments(String css) =>
+    css.replaceAll(COMMENTS, "");
 
   String convertColonHost(String css) {
     css = css.replaceAll(":host", HOST_TOKEN);

--- a/test/core_dom/css_shim_spec.dart
+++ b/test/core_dom/css_shim_spec.dart
@@ -116,5 +116,10 @@ main() {
       var css = s("polyfill-non-strict {} x /deep/ y {}", "a");
       expect(css).toEqual('a x   y {}');
     });
+
+    it("should handle comments", () {
+      var css = s("/*a*/ polyfill-non-strict {} x /deep/ y {}", "a");
+      expect(css).toEqual('a x   y {}');
+    });
   });
 }


### PR DESCRIPTION
As it stands, the CSS comments confuse the parser's ability to recognize
the polyfill-non-strict and friends, as the comments get treated as part
of the selector. This simply strips out the comments before doing any
processing.