### PR TITLE
fix(mock/zone.dart):  `microLeap` assertion that _asyncErrors.isEmpty

### DIFF
--- a/lib/mock/zone.dart
+++ b/lib/mock/zone.dart
@@ -54,7 +54,6 @@ microLeap() {
     _asyncQueue.clear();
     // TODO: Support the case where multiple exceptions are thrown.
     // e.g. with a throwNextException() method.
-    assert(_asyncErrors.isEmpty);
     toRun.forEach((fn) => fn());
     if (_asyncErrors.isNotEmpty) {
       var e = _asyncErrors.removeAt(0);


### PR DESCRIPTION
Remove useless `assert(_asyncErrors.isEmpty)` from `microLeap`.
- asynchronous errors no longer fail to re-throw when running in checked mode.

Closes #1739