### PR TITLE
chore(pubspec): widen dependency on package:analyzer

### DIFF
--- a/lib/core_dom/directive_injector.dart
+++ b/lib/core_dom/directive_injector.dart
@@ -2,7 +2,7 @@ library angular.node_injector;
 
 import 'dart:collection';
 import 'dart:html' show Node, Element, ShadowRoot;
-import 'dart:profiler';
+import 'dart:developer';
 
 import 'package:di/di.dart';
 import 'package:di/annotations.dart';

--- a/lib/tracing.dart
+++ b/lib/tracing.dart
@@ -6,7 +6,7 @@
  */
 library angular.tracing;
 
-import "dart:profiler";
+import "dart:developer";
 
 bool traceEnabled = false;
 dynamic /* JsObject */ _trace;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -12,7 +12,7 @@ packages:
   barback:
     description: barback
     source: hosted
-    version: "0.15.2+4"
+    version: "0.15.2+7"
   benchmark_harness:
     description: benchmark_harness
     source: hosted
@@ -25,26 +25,30 @@ packages:
     description: browser_detect
     source: hosted
     version: "1.0.3"
+  charcode:
+    description: charcode
+    source: hosted
+    version: "1.1.0"
   cli_util:
     description: cli_util
     source: hosted
-    version: "0.0.1+1"
+    version: "0.0.1+2"
   code_transformers:
     description: code_transformers
     source: hosted
-    version: "0.2.8"
+    version: "0.2.9+3"
   collection:
     description: collection
     source: hosted
-    version: "1.1.0"
+    version: "1.1.3"
   csslib:
     description: csslib
     source: hosted
-    version: "0.12.0"
+    version: "0.12.1"
   dart_style:
     description: dart_style
     source: hosted
-    version: "0.1.8"
+    version: "0.1.8+2"
   di:
     description: di
     source: hosted
@@ -52,7 +56,7 @@ packages:
   glob:
     description: glob
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   guinness:
     description: guinness
     source: hosted
@@ -60,7 +64,7 @@ packages:
   html:
     description: html
     source: hosted
-    version: "0.12.1+1"
+    version: "0.12.2"
   html5lib:
     description: html5lib
     source: hosted
@@ -68,7 +72,7 @@ packages:
   initialize:
     description: initialize
     source: hosted
-    version: "0.6.0+5"
+    version: "0.6.1+2"
   intl:
     description: intl
     source: hosted
@@ -80,11 +84,7 @@ packages:
   logging:
     description: logging
     source: hosted
-    version: "0.9.3"
-  matcher:
-    description: matcher
-    source: hosted
-    version: "0.11.4+4"
+    version: "0.11.2"
   meta:
     description: meta
     source: hosted
@@ -92,15 +92,15 @@ packages:
   mock:
     description: mock
     source: hosted
-    version: "0.11.0+2"
+    version: "0.11.0+4"
   observe:
     description: observe
     source: hosted
-    version: "0.13.0+2"
+    version: "0.13.1+2"
   path:
     description: path
     source: hosted
-    version: "1.3.5"
+    version: "1.3.6"
   perf_api:
     description: perf_api
     source: hosted
@@ -108,7 +108,7 @@ packages:
   pool:
     description: pool
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   protractor:
     description: protractor
     source: hosted
@@ -116,31 +116,31 @@ packages:
   route_hierarchical:
     description: route_hierarchical
     source: hosted
-    version: "0.6.1+1"
+    version: "0.6.2"
   smoke:
     description: smoke
     source: hosted
-    version: "0.3.2"
+    version: "0.3.5"
   source_maps:
     description: source_maps
     source: hosted
-    version: "0.10.0+2"
+    version: "0.10.1"
   source_span:
     description: source_span
     source: hosted
-    version: "1.1.2"
+    version: "1.2.1"
   stack_trace:
     description: stack_trace
     source: hosted
-    version: "1.3.1"
+    version: "1.4.2"
   string_scanner:
     description: string_scanner
     source: hosted
-    version: "0.1.3+1"
+    version: "0.1.4"
   unittest:
     description: unittest
     source: hosted
-    version: "0.11.5+4"
+    version: "0.11.6+1"
   utf:
     description: utf
     source: hosted
@@ -148,11 +148,11 @@ packages:
   watcher:
     description: watcher
     source: hosted
-    version: "0.9.5"
+    version: "0.9.7"
   web_components:
     description: web_components
     source: hosted
-    version: "0.11.3+1"
+    version: "0.11.4+2"
   when:
     description: when
     source: hosted

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: angular
-version: '1.1.2'
+version: '1.1.2+1'
 authors:
 - Misko Hevery <misko@hevery.com>
 - Pavel Jbanov <pavelgj@gmail.com>
@@ -14,7 +14,7 @@ homepage: https://angulardart.org
 environment:
   sdk: '>=1.4.0'
 dependencies:
-  analyzer: '>=0.24.0 <0.25.0'
+  analyzer: '>=0.24.0 <0.27.0'
   args: '>=0.12.0 <0.13.0'
   barback: '>=0.13.0 <0.17.0'
   browser: '>=0.10.0 <0.11.0'


### PR DESCRIPTION
The old analyzer depends on dart:profiler, which is deprecated and will be removed in an upcoming version of dart