### PR TITLE
chore: Dart 1.14 compatibility. Platform.packageRoot now returns a URI.

### DIFF
--- a/benchmark/pubspec.lock
+++ b/benchmark/pubspec.lock
@@ -4,21 +4,25 @@ packages:
   analyzer:
     description: analyzer
     source: hosted
-    version: "0.22.4"
+    version: "0.26.4"
   angular:
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.1.2+2"
   args:
     description: args
     source: hosted
-    version: "0.12.2+1"
+    version: "0.12.2+6"
+  async:
+    description: async
+    source: hosted
+    version: "1.8.0"
   barback:
     description: barback
     source: hosted
-    version: "0.15.2+2"
+    version: "0.15.2+7"
   benchmark_harness:
     description: benchmark_harness
     source: hosted
@@ -27,91 +31,128 @@ packages:
     description: browser
     source: hosted
     version: "0.10.0+2"
+  charcode:
+    description: charcode
+    source: hosted
+    version: "1.1.0"
+  cli_util:
+    description: cli_util
+    source: hosted
+    version: "0.0.1+2"
   code_transformers:
     description: code_transformers
     source: hosted
-    version: "0.2.3+2"
+    version: "0.2.11"
   collection:
     description: collection
     source: hosted
-    version: "0.9.4"
+    version: "1.1.3"
   csslib:
     description: csslib
     source: hosted
-    version: "0.11.0+2"
+    version: "0.12.2"
   di:
     description: di
     source: hosted
-    version: "3.3.3"
+    version: "3.3.5+1"
+  glob:
+    description: glob
+    source: hosted
+    version: "1.1.0"
+  html:
+    description: html
+    source: hosted
+    version: "0.12.2+1"
   html5lib:
     description: html5lib
     source: hosted
-    version: "0.12.0"
+    version: "0.12.1"
   intl:
     description: intl
     source: hosted
-    version: "0.11.9"
+    version: "0.8.10+4"
   logging:
     description: logging
     source: hosted
-    version: "0.9.2"
-  matcher:
-    description: matcher
+    version: "0.11.2"
+  meta:
+    description: meta
     source: hosted
-    version: "0.11.1"
+    version: "0.8.8"
   mock:
     description: mock
     source: hosted
-    version: "0.11.0+2"
+    version: "0.11.0+4"
   observe:
     description: observe
     source: hosted
-    version: "0.12.2"
+    version: "0.13.1+3"
+  package_config:
+    description: package_config
+    source: hosted
+    version: "0.1.3"
   path:
     description: path
     source: hosted
-    version: "1.3.0"
+    version: "1.3.9"
   perf_api:
     description: perf_api
     source: hosted
     version: "0.0.9"
-  petitparser:
-    description: petitparser
+  plugin:
+    description: plugin
     source: hosted
-    version: "1.2.2"
+    version: "0.1.0"
   pool:
     description: pool
     source: hosted
-    version: "1.0.1"
+    version: "1.2.1"
   route_hierarchical:
     description: route_hierarchical
     source: hosted
-    version: "0.6.1"
+    version: "0.6.2"
   smoke:
     description: smoke
     source: hosted
-    version: "0.2.1+1"
+    version: "0.3.5"
   source_maps:
     description: source_maps
     source: hosted
-    version: "0.9.4"
+    version: "0.10.1"
   source_span:
     description: source_span
     source: hosted
-    version: "1.0.0"
+    version: "1.2.1"
   stack_trace:
     description: stack_trace
     source: hosted
-    version: "1.1.1"
+    version: "1.6.0"
+  string_scanner:
+    description: string_scanner
+    source: hosted
+    version: "0.1.4+1"
   unittest:
     description: unittest
     source: hosted
-    version: "0.11.0+5"
+    version: "0.11.6+1"
   utf:
     description: utf
     source: hosted
-    version: "0.9.0+1"
+    version: "0.9.0+2"
   watcher:
     description: watcher
     source: hosted
-    version: "0.9.3"
+    version: "0.9.7"
+  when:
+    description: when
+    source: hosted
+    version: "0.2.0"
+  which:
+    description: which
+    source: hosted
+    version: "0.1.3"
+  yaml:
+    description: yaml
+    source: hosted
+    version: "2.1.8"
+sdk: ">=1.12.0 <2.0.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -111,3 +111,4 @@ packages:
     description: web_components
     source: hosted
     version: "0.9.0"
+sdk: ">=1.9.0 <2.0.0"

--- a/lib/tools/expression_extractor.dart
+++ b/lib/tools/expression_extractor.dart
@@ -10,6 +10,7 @@ import 'package:angular/tools/io_impl.dart';
 import 'package:angular/tools/common.dart';
 
 import 'package:di/di.dart';
+import 'package:path/path.dart' as path;
 
 import 'package:angular/core/parser/parser.dart';
 import 'package:angular/core/parser/lexer.dart';
@@ -24,8 +25,9 @@ main(args) {
   }
   IoService ioService = new IoServiceImpl();
 
-  var packageRoots =
-      (args.length < 6) ? [Platform.packageRoot] : args.sublist(5);
+  var packageRoots = (args.length < 6)
+      ? [path.fromUri(Platform.packageRoot ?? '')]
+      : args.sublist(5);
   var sourceCrawler = new SourceCrawlerImpl(packageRoots);
   var sourceMetadataExtractor = new SourceMetadataExtractor();
   List<DirectiveInfo> directives =

--- a/lib/tools/template_cache_generator.dart
+++ b/lib/tools/template_cache_generator.dart
@@ -9,6 +9,7 @@ import 'package:analyzer/src/generated/source.dart';
 import 'package:analyzer/src/generated/element.dart';
 import 'package:args/args.dart';
 import 'package:di/generator.dart';
+import 'package:path/path.dart' as path;
 import 'dart:convert';
 
 const String PACKAGE_PREFIX = 'package:';
@@ -80,7 +81,8 @@ Options parseArgs(List arguments) {
       ..addOption('sdk-path', abbr: 's',
           defaultsTo: Platform.environment['DART_SDK'],
           help: 'Dart SDK Path')
-      ..addOption('package-root', abbr: 'p', defaultsTo: Platform.packageRoot,
+      ..addOption('package-root', abbr: 'p',
+          defaultsTo: Platform.packageRoot ?? '',
           help: 'comma-separated list of package roots')
       ..addOption('template-root', abbr: 't', defaultsTo: '.',
           help: 'comma-separated list of paths from which templates with'
@@ -128,7 +130,8 @@ Options parseArgs(List arguments) {
 
   var options = new Options();
   options.sdkPath = args['sdk-path'];
-  options.packageRoots = args['package-root'].split(',');
+  options.packageRoots =
+      args['package-root'].split(',').map(path.fromUri).toList();
   options.templateRoots = args['template-root'].split(',');
   options.output = args['out'];
   if (args['url-rewrites'] != null) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -161,3 +161,4 @@ packages:
     description: which
     source: hosted
     version: "0.1.3"
+sdk: ">=1.9.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dev_dependencies:
   benchmark_harness: '>=1.0.0 <2.0.0'
   guinness: '>=0.1.9 <0.2.0'
   mock: '>=0.10.0 <0.12.0'
+  path: '>=1.1.0 <2.0.0'
   protractor: '0.0.5'
   unittest: '>=0.10.1 <0.12.0'
   web_components: '>=0.11.1 <0.12.0'

--- a/test_e2e/pubspec.yaml
+++ b/test_e2e/pubspec.yaml
@@ -1,4 +1,4 @@
-name: angulardart-specs
+name: angulardart_specs
 version: 0.0.1
 authors:
 - Chirayu Krishnappa <chirayu@chirayuk.com>


### PR DESCRIPTION
As of Dart SDK 1.14.0, pubspec.lock files now include an SDK constraint.

Prior to Dart SDK 1.14.0, Platform.packageRoot could return either a path or a URI (e.g. http). As of 1.14, it will return one of:
   * `null`: if the VM `--package-root` is not specified
   * a URI: if either a path or a URI is specified via `--package-root`